### PR TITLE
feat: notebook producer integration and chat with document context

### DIFF
--- a/deployments/overlays/dev/kustomization.yaml
+++ b/deployments/overlays/dev/kustomization.yaml
@@ -21,4 +21,5 @@ commonLabels:
 
 images:
   - name: aether-backend
+    newName: registry-api.tas.scharber.com/aether-backend
     newTag: dev

--- a/internal/agents/internal_agents.go
+++ b/internal/agents/internal_agents.go
@@ -1,0 +1,119 @@
+package agents
+
+import (
+	"time"
+
+	"github.com/Tributary-ai-services/aether-be/internal/models"
+)
+
+// InternalAgent represents a system agent configuration
+type InternalAgent struct {
+	ID           string                 `json:"id"`
+	Name         string                 `json:"name"`
+	Description  string                 `json:"description"`
+	Type         string                 `json:"type"`
+	SystemPrompt string                 `json:"system_prompt"`
+	LLMConfig    map[string]interface{} `json:"llm_config"`
+	IsInternal   bool                   `json:"is_internal"`
+	CreatedAt    string                 `json:"created_at"`
+}
+
+// Well-known internal agent IDs
+const (
+	PromptAssistantID        = "00000000-0000-0000-0000-000000000001"
+	PostgreSQLAssistantID    = "00000000-0000-0000-0000-000000000002"
+	MySQLAssistantID         = "00000000-0000-0000-0000-000000000003"
+	MariaDBAssistantID       = "00000000-0000-0000-0000-000000000004"
+	SQLServerAssistantID     = "00000000-0000-0000-0000-000000000005"
+	SQLiteAssistantID        = "00000000-0000-0000-0000-000000000006"
+	DuckDBAssistantID        = "00000000-0000-0000-0000-000000000007"
+	Neo4jAssistantID         = "00000000-0000-0000-0000-000000000008"
+	NotebookChatAssistantID  = "00000000-0000-0000-0000-000000000009"
+	DocumentSummarizerID     = "00000000-0000-0000-0000-000000000010"
+	QAGeneratorID            = "00000000-0000-0000-0000-000000000011"
+	OutlineCreatorID         = "00000000-0000-0000-0000-000000000012"
+	InsightsExtractorID      = "00000000-0000-0000-0000-000000000013"
+)
+
+// GetInternalAgents returns the list of all internal system agents.
+// DEPRECATED: Internal agents are now stored in agent-builder database.
+// This function returns an empty list for backward compatibility.
+// The agents are seeded via SQL migrations in tas-agent-builder/database/migrations/016_seed_producer_agents.sql
+// To modify agent prompts, update the database directly or via migrations - no code deployment required.
+func GetInternalAgents() []InternalAgent {
+	// Return empty list - internal agents now come from agent-builder
+	return []InternalAgent{}
+}
+
+// GetInternalProducerAgents returns only internal agents of type "producer"
+func GetInternalProducerAgents() []InternalAgent {
+	allAgents := GetInternalAgents()
+	producers := make([]InternalAgent, 0)
+	for _, agent := range allAgents {
+		if agent.Type == "producer" {
+			producers = append(producers, agent)
+		}
+	}
+	return producers
+}
+
+// GetInternalConversationalAgents returns only internal agents of type "conversational"
+func GetInternalConversationalAgents() []InternalAgent {
+	allAgents := GetInternalAgents()
+	conversational := make([]InternalAgent, 0)
+	for _, agent := range allAgents {
+		if agent.Type == "conversational" {
+			conversational = append(conversational, agent)
+		}
+	}
+	return conversational
+}
+
+// GetInternalAgentByID returns an internal agent by ID, or nil if not found
+func GetInternalAgentByID(id string) *InternalAgent {
+	for _, agent := range GetInternalAgents() {
+		if agent.ID == id {
+			return &agent
+		}
+	}
+	return nil
+}
+
+// IsInternalAgentID checks if the given ID is an internal agent ID
+func IsInternalAgentID(id string) bool {
+	return GetInternalAgentByID(id) != nil
+}
+
+// ToAgentResponse converts an InternalAgent to a models.AgentResponse
+func (a *InternalAgent) ToAgentResponse() *models.AgentResponse {
+	createdAt, _ := time.Parse(time.RFC3339, a.CreatedAt)
+
+	return &models.AgentResponse{
+		ID:             a.ID,
+		AgentBuilderID: a.ID, // Internal agents use same ID
+		Name:           a.Name,
+		Description:    a.Description,
+		Status:         models.AgentStatusPublished, // Internal agents are always published
+		Type:           models.AgentType(a.Type),
+		OwnerID:        "system",
+		SpaceType:      models.SpaceTypePersonal, // Internal agents are available in all spaces
+		SpaceID:        "",                       // Internal agents are not space-scoped
+		IsPublic:       true,                     // Internal agents are always public
+		IsTemplate:     false,
+		Tags:           []string{"internal", "system"},
+		SystemPrompt:   a.SystemPrompt,
+		LLMConfig:      a.LLMConfig,
+		CreatedAt:      createdAt,
+		UpdatedAt:      createdAt,
+	}
+}
+
+// GetInternalProducerAgentResponses returns internal producer agents as AgentResponse objects
+func GetInternalProducerAgentResponses() []*models.AgentResponse {
+	producers := GetInternalProducerAgents()
+	responses := make([]*models.AgentResponse, 0, len(producers))
+	for _, agent := range producers {
+		responses = append(responses, agent.ToAgentResponse())
+	}
+	return responses
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -214,10 +214,11 @@ type ProxyRoute struct {
 
 // Crawl4AIConfig holds Crawl4AI web scraping service configuration
 type Crawl4AIConfig struct {
-	BaseURL        string `json:"base_url"`
-	Enabled        bool   `json:"enabled"`
-	TimeoutSeconds int    `json:"timeout_seconds"`
-	MaxRetries     int    `json:"max_retries"`
+	BaseURL         string `json:"base_url"`
+	Enabled         bool   `json:"enabled"`
+	TimeoutSeconds  int    `json:"timeout_seconds"`
+	MaxRetries      int    `json:"max_retries"`
+	SanitizeContent bool   `json:"sanitize_content"` // Enable XSS/security sanitization of scraped content
 }
 
 // DBHubConfig holds DBHub MCP server configuration
@@ -367,10 +368,11 @@ func Load() (*Config, error) {
 			ProxyRoutes: getDefaultProxyRoutes(),
 		},
 		Crawl4AI: Crawl4AIConfig{
-			BaseURL:        getEnv("CRAWL4AI_BASE_URL", "http://crawl4ai.tas-mcp-servers.svc.cluster.local:11235"),
-			Enabled:        getEnvBool("CRAWL4AI_ENABLED", true),
-			TimeoutSeconds: getEnvInt("CRAWL4AI_TIMEOUT_SECONDS", 60),
-			MaxRetries:     getEnvInt("CRAWL4AI_MAX_RETRIES", 3),
+			BaseURL:         getEnv("CRAWL4AI_BASE_URL", "http://crawl4ai.tas-mcp-servers.svc.cluster.local:11235"),
+			Enabled:         getEnvBool("CRAWL4AI_ENABLED", true),
+			TimeoutSeconds:  getEnvInt("CRAWL4AI_TIMEOUT_SECONDS", 60),
+			MaxRetries:      getEnvInt("CRAWL4AI_MAX_RETRIES", 3),
+			SanitizeContent: getEnvBool("CRAWL4AI_SANITIZE_CONTENT", true), // Default to enabled for security
 		},
 		DBHub: DBHubConfig{
 			BaseURL:        getEnv("DBHUB_BASE_URL", "http://dbhub.tas-mcp-servers.svc.cluster.local:8080"),

--- a/internal/handlers/agent.go
+++ b/internal/handlers/agent.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 
+	"github.com/Tributary-ai-services/aether-be/internal/agents"
 	"github.com/Tributary-ai-services/aether-be/internal/logger"
 	"github.com/Tributary-ai-services/aether-be/internal/middleware"
 	"github.com/Tributary-ai-services/aether-be/internal/models"
@@ -736,476 +737,12 @@ func (h *AgentHandler) ListExecutions(c *gin.Context) {
 // Internal Agent Handlers - System agents like Prompt Assistant
 // ============================================================================
 
-// InternalAgent represents a system agent configuration
-type InternalAgent struct {
-	ID           string                 `json:"id"`
-	Name         string                 `json:"name"`
-	Description  string                 `json:"description"`
-	Type         string                 `json:"type"`
-	SystemPrompt string                 `json:"system_prompt"`
-	LLMConfig    map[string]interface{} `json:"llm_config"`
-	IsInternal   bool                   `json:"is_internal"`
-	CreatedAt    string                 `json:"created_at"`
-}
+// InternalAgent is an alias for the shared internal agent type
+type InternalAgent = agents.InternalAgent
 
-// getInternalAgents returns the list of internal system agents
-func getInternalAgents() []InternalAgent {
-	return []InternalAgent{
-		{
-			ID:          "00000000-0000-0000-0000-000000000001",
-			Name:        "Prompt Assistant",
-			Description: "AI-powered assistant for improving agent descriptions and system prompts",
-			Type:        "conversational",
-			SystemPrompt: `You are a helpful AI assistant specialized in writing and improving prompts for AI agents.
-
-Your role is to help users create effective:
-1. Agent descriptions - Clear, concise descriptions that explain what the agent does
-2. System prompts - Well-structured instructions that guide agent behavior
-
-When helping with descriptions:
-- Keep them concise (1-3 sentences)
-- Focus on the agent's primary purpose and capabilities
-- Use clear, professional language
-
-When helping with system prompts:
-- Structure them with clear sections (role, capabilities, constraints)
-- Include specific instructions for the agent's behavior
-- Consider edge cases and error handling
-- Use consistent formatting
-
-Always respond with a JSON object in this format:
-{
-  "recommendation": "Your suggested text here",
-  "reasoning": "Brief explanation of why this works well",
-  "comments": "Any questions or suggestions for further refinement"
-}
-
-Be conversational and helpful. Ask clarifying questions if needed.`,
-			LLMConfig: map[string]interface{}{
-				"provider":    "openai",
-				"model":       "gpt-4o-mini",
-				"temperature": 0.7,
-				"max_tokens":  1024,
-			},
-			IsInternal: true,
-			CreatedAt:  "2024-01-01T00:00:00Z",
-		},
-		{
-			ID:          "00000000-0000-0000-0000-000000000002",
-			Name:        "PostgreSQL Query Assistant",
-			Description: "Expert PostgreSQL assistant for writing, optimizing, and debugging SQL queries with support for PostgreSQL-specific features",
-			Type:        "conversational",
-			SystemPrompt: `You are an expert PostgreSQL database assistant helping users write and optimize SQL queries.
-
-Your role is to help users:
-1. Write correct and efficient SELECT, INSERT, UPDATE, and DELETE queries
-2. Leverage PostgreSQL-specific features for optimal solutions
-3. Optimize query performance and suggest indexing strategies
-4. Debug and fix problematic queries
-
-PostgreSQL-Specific Features to Leverage:
-- Common Table Expressions (WITH clauses) for readable, maintainable queries
-- Window functions (ROW_NUMBER, RANK, DENSE_RANK, LAG, LEAD, NTILE)
-- JSONB operations (containment @>, extraction ->>, path queries #>>)
-- Array operations (ANY, ALL, array_agg, unnest)
-- Full-text search (tsvector, tsquery, to_tsvector, to_tsquery)
-- LATERAL joins for correlated subqueries
-- DISTINCT ON for PostgreSQL-specific deduplication
-- UPSERT with ON CONFLICT DO UPDATE/NOTHING
-- Recursive CTEs for hierarchical data
-- Date/time functions (date_trunc, generate_series, intervals)
-
-Performance Guidelines:
-- Recommend appropriate index types (B-tree, GIN, GiST, BRIN) based on use case
-- Suggest EXPLAIN ANALYZE for query analysis
-- Advise on proper use of transactions and isolation levels
-- Warn about common performance pitfalls (N+1 queries, missing indexes, sequential scans)
-
-Best Practices:
-- Use parameterized queries to prevent SQL injection
-- Prefer explicit column lists over SELECT *
-- Use appropriate data types
-- Consider NULL handling with COALESCE or NULLIF
-- Use meaningful table aliases for readability
-
-Always respond with a JSON object in this format:
-{
-  "recommendation": "The SQL query with proper formatting and comments",
-  "reasoning": "Brief explanation of why this approach works well for PostgreSQL",
-  "comments": "Questions for clarification or additional performance/design considerations"
-}
-
-When the user provides a schema or existing query, analyze it and provide tailored suggestions. Ask clarifying questions about expected data volumes, access patterns, and performance requirements when relevant.`,
-			LLMConfig: map[string]interface{}{
-				"provider":    "openai",
-				"model":       "gpt-4o",
-				"temperature": 0.7,
-				"max_tokens":  1000,
-			},
-			IsInternal: true,
-			CreatedAt:  "2024-01-01T00:00:00Z",
-		},
-		{
-			ID:          "00000000-0000-0000-0000-000000000003",
-			Name:        "MySQL Query Assistant",
-			Description: "Expert MySQL assistant for writing, optimizing, and debugging SQL queries with support for MySQL-specific features",
-			Type:        "conversational",
-			SystemPrompt: `You are an expert MySQL database assistant helping users write and optimize SQL queries.
-
-Your role is to help users:
-1. Write correct and efficient SELECT, INSERT, UPDATE, and DELETE queries
-2. Leverage MySQL-specific features for optimal solutions
-3. Optimize query performance and suggest indexing strategies
-4. Debug and fix problematic queries
-
-MySQL-Specific Features to Leverage:
-- Storage engines (InnoDB vs MyISAM) and their use cases
-- JSON functions (JSON_EXTRACT, JSON_ARRAY, JSON_OBJECT, ->> operator in 8.0+)
-- Window functions (ROW_NUMBER, RANK, DENSE_RANK, LAG, LEAD - MySQL 8.0+)
-- Common Table Expressions (WITH clauses - MySQL 8.0+)
-- Full-text search (MATCH...AGAINST with natural language and boolean modes)
-- Generated columns (virtual and stored)
-- INSERT...ON DUPLICATE KEY UPDATE for upserts
-- GROUP_CONCAT for string aggregation
-- User-defined variables and session variables
-- Stored procedures, functions, and triggers
-- EXPLAIN and EXPLAIN ANALYZE for query optimization
-
-Performance Guidelines:
-- Index types: B-tree (default), Full-text, Spatial, Hash (MEMORY tables)
-- Use EXPLAIN to analyze query execution plans
-- Understand InnoDB buffer pool and query cache behavior
-- Optimize JOINs with proper indexing and join order
-- Use covering indexes when possible
-
-Best Practices:
-- Use parameterized queries/prepared statements to prevent SQL injection
-- Prefer explicit column lists over SELECT *
-- Use appropriate data types (VARCHAR vs TEXT, INT vs BIGINT)
-- Handle NULL properly with COALESCE, IFNULL, or NULLIF
-- Consider character sets and collations (utf8mb4 recommended)
-
-Always respond with a JSON object in this format:
-{
-  "recommendation": "The SQL query with proper formatting and comments",
-  "reasoning": "Brief explanation of why this approach works well for MySQL",
-  "comments": "Questions for clarification or additional performance/design considerations"
-}`,
-			LLMConfig: map[string]interface{}{
-				"provider":    "openai",
-				"model":       "gpt-4o",
-				"temperature": 0.7,
-				"max_tokens":  1000,
-			},
-			IsInternal: true,
-			CreatedAt:  "2024-01-01T00:00:00Z",
-		},
-		{
-			ID:          "00000000-0000-0000-0000-000000000004",
-			Name:        "MariaDB Query Assistant",
-			Description: "Expert MariaDB assistant for writing, optimizing, and debugging SQL queries with support for MariaDB-specific features",
-			Type:        "conversational",
-			SystemPrompt: `You are an expert MariaDB database assistant helping users write and optimize SQL queries.
-
-Your role is to help users:
-1. Write correct and efficient SELECT, INSERT, UPDATE, and DELETE queries
-2. Leverage MariaDB-specific features for optimal solutions
-3. Optimize query performance and suggest indexing strategies
-4. Debug and fix problematic queries
-
-MariaDB-Specific Features (Beyond MySQL Compatibility):
-- Sequences (CREATE SEQUENCE) for portable auto-increment alternatives
-- System-versioned tables (temporal tables) for historical data tracking
-- Invisible columns for schema evolution
-- Oracle compatibility mode (sql_mode=ORACLE)
-- Storage engines: Aria (crash-safe MyISAM replacement), ColumnStore, Spider
-- Window functions (available earlier than MySQL 8.0)
-- Common Table Expressions with recursive support
-- JSON functions and JSON table support
-- CHECK constraints (enforced, unlike older MySQL)
-- DEFAULT expressions with functions
-- RETURNING clause for INSERT/UPDATE/DELETE
-- EXCEPT and INTERSECT operators
-- Galera Cluster for synchronous multi-master replication
-
-Performance Guidelines:
-- Use EXPLAIN and ANALYZE for query optimization
-- Leverage the query cache (still available in MariaDB)
-- Optimize with proper indexing (B-tree, Full-text, Spatial)
-- Consider ColumnStore for analytics workloads
-
-Best Practices:
-- Use parameterized queries/prepared statements to prevent SQL injection
-- Prefer explicit column lists over SELECT *
-- Use appropriate data types
-- Leverage CHECK constraints for data validation
-
-Always respond with a JSON object in this format:
-{
-  "recommendation": "The SQL query with proper formatting and comments",
-  "reasoning": "Brief explanation of why this approach works well for MariaDB",
-  "comments": "Questions for clarification or additional performance/design considerations"
-}`,
-			LLMConfig: map[string]interface{}{
-				"provider":    "openai",
-				"model":       "gpt-4o",
-				"temperature": 0.7,
-				"max_tokens":  1000,
-			},
-			IsInternal: true,
-			CreatedAt:  "2024-01-01T00:00:00Z",
-		},
-		{
-			ID:          "00000000-0000-0000-0000-000000000005",
-			Name:        "SQL Server Query Assistant",
-			Description: "Expert Microsoft SQL Server assistant for writing, optimizing, and debugging T-SQL queries",
-			Type:        "conversational",
-			SystemPrompt: `You are an expert Microsoft SQL Server database assistant helping users write and optimize T-SQL queries.
-
-Your role is to help users:
-1. Write correct and efficient SELECT, INSERT, UPDATE, and DELETE queries using T-SQL
-2. Leverage SQL Server-specific features for optimal solutions
-3. Optimize query performance and suggest indexing strategies
-4. Debug and fix problematic queries
-
-SQL Server-Specific Features to Leverage:
-- Common Table Expressions (WITH clauses) including recursive CTEs
-- Window functions (ROW_NUMBER, RANK, DENSE_RANK, NTILE, LAG, LEAD)
-- CROSS APPLY and OUTER APPLY for correlated subqueries
-- MERGE statement for upsert operations
-- OUTPUT clause for capturing affected rows
-- Temporal tables (system-versioned) for historical data
-- JSON functions (JSON_VALUE, JSON_QUERY, OPENJSON, FOR JSON)
-- STRING_AGG and STRING_SPLIT functions
-- TRY_CAST, TRY_CONVERT for safe type conversion
-- OFFSET-FETCH for pagination
-- Columnstore indexes for analytics
-- Query hints (NOLOCK, ROWLOCK, OPTION RECOMPILE, etc.)
-
-Performance Guidelines:
-- Use execution plans (SET SHOWPLAN_XML, Include Actual Execution Plan)
-- Understand index types: clustered, non-clustered, filtered, columnstore
-- Use covering indexes and included columns
-- Avoid parameter sniffing issues with OPTION (RECOMPILE) or OPTIMIZE FOR
-
-Best Practices:
-- Use parameterized queries/sp_executesql to prevent SQL injection
-- Prefer explicit column lists over SELECT *
-- Use appropriate data types (NVARCHAR vs VARCHAR, DATE vs DATETIME2)
-- Use TRY...CATCH for error handling
-- Use schema names explicitly (dbo.TableName)
-
-Always respond with a JSON object in this format:
-{
-  "recommendation": "The T-SQL query with proper formatting and comments",
-  "reasoning": "Brief explanation of why this approach works well for SQL Server",
-  "comments": "Questions for clarification or additional performance/design considerations"
-}`,
-			LLMConfig: map[string]interface{}{
-				"provider":    "openai",
-				"model":       "gpt-4o",
-				"temperature": 0.7,
-				"max_tokens":  1000,
-			},
-			IsInternal: true,
-			CreatedAt:  "2024-01-01T00:00:00Z",
-		},
-		{
-			ID:          "00000000-0000-0000-0000-000000000006",
-			Name:        "SQLite Query Assistant",
-			Description: "Expert SQLite assistant for writing, optimizing, and debugging SQL queries with support for SQLite-specific features",
-			Type:        "conversational",
-			SystemPrompt: `You are an expert SQLite database assistant helping users write and optimize SQL queries.
-
-Your role is to help users:
-1. Write correct and efficient SELECT, INSERT, UPDATE, and DELETE queries
-2. Leverage SQLite-specific features for optimal solutions
-3. Optimize query performance within SQLite's constraints
-4. Debug and fix problematic queries
-
-SQLite-Specific Features to Leverage:
-- Dynamic typing and type affinity system
-- JSON functions (json_extract, json_array, json_object, -> and ->> operators)
-- Window functions (ROW_NUMBER, RANK, DENSE_RANK, LAG, LEAD, etc.)
-- Common Table Expressions (WITH clauses) including recursive CTEs
-- Full-text search with FTS5 extension
-- R-tree indexes for spatial data
-- Generated columns (stored and virtual)
-- UPSERT with ON CONFLICT clause
-- RETURNING clause for INSERT/UPDATE/DELETE
-- GROUP_CONCAT for string aggregation
-- Date/time functions (date, time, datetime, julianday, strftime)
-- WITHOUT ROWID tables for optimization
-
-Performance Guidelines:
-- Use EXPLAIN QUERY PLAN to analyze queries
-- Create appropriate indexes (SQLite uses B-tree)
-- Use WAL mode for better concurrency
-- Use transactions for batch operations (much faster)
-- Consider memory-mapped I/O for large databases
-
-SQLite Limitations to Consider:
-- No RIGHT or FULL OUTER JOIN (use LEFT JOIN with UNION)
-- Limited ALTER TABLE capabilities
-- Single-writer model (consider WAL mode)
-- No native BOOLEAN type (use 0/1 integers)
-
-Best Practices:
-- Use parameterized queries to prevent SQL injection
-- Use INTEGER PRIMARY KEY for auto-increment (implicit rowid alias)
-- Enable foreign key enforcement: PRAGMA foreign_keys = ON
-- Consider STRICT tables (SQLite 3.37+) for type enforcement
-
-Always respond with a JSON object in this format:
-{
-  "recommendation": "The SQL query with proper formatting and comments",
-  "reasoning": "Brief explanation of why this approach works well for SQLite",
-  "comments": "Questions for clarification or additional considerations"
-}`,
-			LLMConfig: map[string]interface{}{
-				"provider":    "openai",
-				"model":       "gpt-4o",
-				"temperature": 0.7,
-				"max_tokens":  1000,
-			},
-			IsInternal: true,
-			CreatedAt:  "2024-01-01T00:00:00Z",
-		},
-		{
-			ID:          "00000000-0000-0000-0000-000000000007",
-			Name:        "DuckDB Query Assistant",
-			Description: "Expert DuckDB assistant for writing and optimizing analytical SQL queries with support for direct file querying",
-			Type:        "conversational",
-			SystemPrompt: `You are an expert DuckDB database assistant helping users write and optimize analytical SQL queries.
-
-Your role is to help users:
-1. Write efficient analytical queries for data analysis and transformation
-2. Leverage DuckDB-specific features for optimal performance
-3. Query external files directly (Parquet, CSV, JSON) without loading
-4. Debug and optimize complex analytical workloads
-
-DuckDB-Specific Features to Leverage:
-- Direct file querying: read_parquet(), read_csv(), read_json()
-- Glob patterns for multiple files: read_parquet('data/*.parquet')
-- Remote file access: read_parquet('s3://bucket/file.parquet')
-- COPY TO for exporting to various formats
-- Columnar storage with automatic compression
-- Parallel query execution
-- Window functions with full SQL:2003 support
-- QUALIFY clause for filtering window function results
-- SAMPLE clause for random sampling
-- ASOF joins for time-series data
-- LIST and STRUCT types for nested data
-- UNNEST for working with arrays
-- PIVOT and UNPIVOT operations
-- Friendly SQL extensions (EXCLUDE, REPLACE, COLUMNS expressions)
-
-Performance Guidelines:
-- DuckDB automatically parallelizes queries - no hints needed
-- Use Parquet format for best performance
-- Leverage predicate pushdown with partitioned data
-- Use EXPLAIN ANALYZE to understand query plans
-
-Analytical Query Patterns:
-- Time-series analysis with window functions
-- ROLLUP, CUBE, GROUPING SETS for multi-level aggregation
-- Percentiles with PERCENTILE_CONT and PERCENTILE_DISC
-- Moving averages and running totals
-
-Best Practices:
-- Use parameterized queries for security
-- Prefer column projection (list needed columns)
-- Use CTEs for readable complex queries
-- Leverage QUALIFY instead of subqueries for window filtering
-
-Always respond with a JSON object in this format:
-{
-  "recommendation": "The SQL query with proper formatting and comments",
-  "reasoning": "Brief explanation of why this approach works well for DuckDB analytics",
-  "comments": "Questions for clarification or additional performance/design considerations"
-}`,
-			LLMConfig: map[string]interface{}{
-				"provider":    "openai",
-				"model":       "gpt-4o",
-				"temperature": 0.7,
-				"max_tokens":  1000,
-			},
-			IsInternal: true,
-			CreatedAt:  "2024-01-01T00:00:00Z",
-		},
-		{
-			ID:          "00000000-0000-0000-0000-000000000008",
-			Name:        "Neo4j Query Assistant",
-			Description: "Expert Neo4j assistant for writing, optimizing, and debugging Cypher queries for graph databases",
-			Type:        "conversational",
-			SystemPrompt: `You are an expert Neo4j graph database assistant helping users write and optimize Cypher queries.
-
-Your role is to help users:
-1. Write correct and efficient Cypher queries for graph operations
-2. Model data effectively as nodes and relationships
-3. Leverage Neo4j-specific features for optimal solutions
-4. Optimize query performance with proper indexing and patterns
-
-Cypher Query Fundamentals:
-- MATCH patterns: (n:Label)-[r:REL_TYPE]->(m:Label)
-- CREATE, MERGE, SET, DELETE, REMOVE for mutations
-- WHERE clauses with property filters and pattern predicates
-- RETURN with aggregations and projections
-- WITH for query chaining and intermediate results
-- OPTIONAL MATCH for outer-join-like behavior
-- UNWIND for working with lists
-
-Advanced Cypher Features:
-- Variable-length paths: (a)-[*1..5]->(b)
-- Shortest path: shortestPath((a)-[*]-(b))
-- Pattern comprehensions: [(n)-->(m) | m.name]
-- List comprehensions: [x IN list WHERE x > 0 | x * 2]
-- COLLECT, REDUCE, and list functions
-- EXISTS and COUNT subqueries
-- CALL subqueries for complex logic
-- Map projections: node {.prop1, .prop2, newProp: expr}
-
-APOC Procedures (Common):
-- apoc.periodic.iterate for batch operations
-- apoc.load.json, apoc.load.csv for data import
-- apoc.path.expand for advanced path finding
-
-Graph Data Science (GDS):
-- Centrality algorithms: PageRank, Betweenness, Degree
-- Community detection: Louvain, Label Propagation
-- Path finding: Dijkstra, A*, Yen's K-shortest
-
-Performance Guidelines:
-- Create indexes on frequently queried properties
-- Use node labels to limit scans
-- Profile queries with PROFILE prefix
-- Avoid cartesian products (multiple unconnected patterns)
-- Use parameters instead of literals
-- Limit variable-length path depth
-
-Best Practices:
-- Use meaningful node labels (PascalCase) and relationship types (UPPER_SNAKE_CASE)
-- Use parameterized queries: $paramName
-- Create constraints for uniqueness (also creates index)
-- Design for your most common traversals
-
-Always respond with a JSON object in this format:
-{
-  "recommendation": "The Cypher query with proper formatting and comments",
-  "reasoning": "Brief explanation of why this approach works well for Neo4j",
-  "comments": "Questions for clarification or additional considerations"
-}`,
-			LLMConfig: map[string]interface{}{
-				"provider":    "openai",
-				"model":       "gpt-4o",
-				"temperature": 0.7,
-				"max_tokens":  1000,
-			},
-			IsInternal: true,
-			CreatedAt:  "2024-01-01T00:00:00Z",
-		},
-	}
-}
+// NotebookChatAssistantID is the ID of the internal notebook chat agent
+// Using the constant from the shared agents package
+const NotebookChatAssistantID = agents.NotebookChatAssistantID
 
 // ListInternalAgents lists all internal system agents
 // @Summary List internal agents
@@ -1217,7 +754,20 @@ Always respond with a JSON object in this format:
 // @Failure 401 {object} errors.APIError
 // @Router /api/v1/agents/internal [get]
 func (h *AgentHandler) ListInternalAgents(c *gin.Context) {
-	agents := getInternalAgents()
+	authToken := extractAuthToken(c)
+	if authToken == "" {
+		h.logger.Warn("No authorization token provided for listing internal agents")
+		c.JSON(http.StatusUnauthorized, errors.Unauthorized("Authorization token required"))
+		return
+	}
+
+	agents, err := h.agentService.GetInternalAgents(c.Request.Context(), authToken)
+	if err != nil {
+		h.logger.Error("Failed to fetch internal agents from agent-builder", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, errors.Internal("Failed to fetch internal agents"))
+		return
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"agents": agents,
 		"total":  len(agents),
@@ -1242,15 +792,29 @@ func (h *AgentHandler) GetInternalAgent(c *gin.Context) {
 		return
 	}
 
-	agents := getInternalAgents()
-	for _, agent := range agents {
-		if agent.ID == agentID {
-			c.JSON(http.StatusOK, agent)
-			return
-		}
+	authToken := extractAuthToken(c)
+	if authToken == "" {
+		h.logger.Warn("No authorization token provided for getting internal agent")
+		c.JSON(http.StatusUnauthorized, errors.Unauthorized("Authorization token required"))
+		return
 	}
 
-	c.JSON(http.StatusNotFound, errors.NotFound("Internal agent not found"))
+	agent, err := h.agentService.GetInternalAgentByID(c.Request.Context(), agentID, authToken)
+	if err != nil {
+		h.logger.Error("Failed to fetch internal agent from agent-builder",
+			zap.Error(err),
+			zap.String("agent_id", agentID),
+		)
+		c.JSON(http.StatusInternalServerError, errors.Internal("Failed to fetch internal agent"))
+		return
+	}
+
+	if agent == nil {
+		c.JSON(http.StatusNotFound, errors.NotFound("Internal agent not found"))
+		return
+	}
+
+	c.JSON(http.StatusOK, agent)
 }
 
 // InternalAgentExecuteRequest represents a request to execute an internal agent
@@ -1303,33 +867,15 @@ func (h *AgentHandler) ExecuteInternalAgent(c *gin.Context) {
 		return
 	}
 
-	// Find the internal agent
-	var targetAgent *InternalAgent
-	agents := getInternalAgents()
-	h.logger.Debug("Available internal agents",
-		zap.Int("count", len(agents)),
-	)
-
-	for _, agent := range agents {
-		if agent.ID == agentID {
-			targetAgent = &agent
-			break
-		}
-	}
-
-	if targetAgent == nil {
-		h.logger.Warn("Internal agent not found",
-			zap.String("requested_id", agentID),
-		)
-		c.JSON(http.StatusNotFound, errors.NotFound("Internal agent not found"))
+	// Get auth token for agent-builder
+	authToken := extractAuthToken(c)
+	if authToken == "" {
+		h.logger.Warn("No authorization token provided")
+		c.JSON(http.StatusUnauthorized, errors.Unauthorized("Authorization token required"))
 		return
 	}
 
-	h.logger.Info("Found internal agent",
-		zap.String("agent_id", targetAgent.ID),
-		zap.String("agent_name", targetAgent.Name),
-	)
-
+	// Parse the request body
 	var req InternalAgentExecuteRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		h.logger.Error("Invalid request payload", zap.Error(err))
@@ -1342,59 +888,49 @@ func (h *AgentHandler) ExecuteInternalAgent(c *gin.Context) {
 		zap.Int("history_length", len(req.History)),
 	)
 
-	// Get auth token for LLM router
-	authToken := extractAuthToken(c)
-	if authToken == "" {
-		h.logger.Warn("No authorization token provided")
-		c.JSON(http.StatusUnauthorized, errors.Unauthorized("Authorization token required"))
-		return
+	// Build service request with conversation history support
+	serviceReq := services.InternalAgentExecuteRequest{
+		Input:     req.Input,
+		SessionID: req.SessionID,
+		Context:   req.Context,
 	}
 
-	// Build messages for LLM
-	messages := []map[string]string{
-		{
-			"role":    "system",
-			"content": targetAgent.SystemPrompt,
-		},
-	}
-
-	// Add conversation history
+	// Convert conversation history
 	for _, msg := range req.History {
-		messages = append(messages, map[string]string{
-			"role":    msg.Role,
-			"content": msg.Content,
+		serviceReq.History = append(serviceReq.History, services.ConversationMessage{
+			Role:      msg.Role,
+			Content:   msg.Content,
+			Timestamp: msg.Timestamp,
 		})
 	}
 
-	// Add current user message
-	messages = append(messages, map[string]string{
-		"role":    "user",
-		"content": req.Input,
-	})
-
-	// Execute via LLM router
-	output, err := h.executeLLMRequest(c.Request.Context(), messages, targetAgent.LLMConfig, authToken)
+	// Execute via agent-builder service
+	response, err := h.agentService.ExecuteInternalAgent(c.Request.Context(), agentID, serviceReq, authToken)
 	if err != nil {
-		h.logger.Error("Failed to execute internal agent", zap.Error(err))
+		h.logger.Error("Failed to execute internal agent via agent-builder",
+			zap.Error(err),
+			zap.String("agent_id", agentID),
+		)
+		// Check if it's a not found error
+		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "404") {
+			c.JSON(http.StatusNotFound, errors.NotFound("Internal agent not found"))
+			return
+		}
 		c.JSON(http.StatusInternalServerError, errors.Internal("Failed to execute agent"))
 		return
 	}
 
-	response := InternalAgentExecuteResponse{
-		Output:         output,
-		ConversationID: req.SessionID,
-		Metadata: map[string]interface{}{
-			"agent_id":   targetAgent.ID,
-			"agent_name": targetAgent.Name,
-		},
-	}
-
-	h.logger.Info("Internal agent executed successfully",
+	h.logger.Info("Internal agent executed successfully via agent-builder",
 		zap.String("agent_id", agentID),
-		zap.String("agent_name", targetAgent.Name),
+		zap.String("execution_id", response.ExecutionID),
 	)
 
-	c.JSON(http.StatusOK, response)
+	// Return response in the format expected by the frontend
+	c.JSON(http.StatusOK, InternalAgentExecuteResponse{
+		Output:         response.Output,
+		ConversationID: response.ConversationID,
+		Metadata:       response.Metadata,
+	})
 }
 
 // executeLLMRequest sends a request to the LLM router

--- a/internal/handlers/notebook.go
+++ b/internal/handlers/notebook.go
@@ -425,3 +425,176 @@ func (h *NotebookHandler) ShareNotebook(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"message": "Notebook shared successfully"})
 }
+
+// ============================================================================
+// Internal API handlers for service-to-service communication
+// These handlers bypass space context middleware for internal service calls
+// ============================================================================
+
+// GetNotebookHierarchy gets notebook hierarchy including sub-notebooks
+// @Summary Get notebook hierarchy
+// @Description Get notebook with recursive sub-notebook hierarchy
+// @Tags internal-notebooks
+// @Accept json
+// @Produce json
+// @Param id path string true "Notebook ID"
+// @Param tenant_id query string true "Tenant ID"
+// @Success 200 {object} models.NotebookHierarchyResponse
+// @Failure 400 {object} errors.APIError
+// @Failure 404 {object} errors.APIError
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/internal/notebooks/{id}/hierarchy [get]
+func (h *NotebookHandler) GetNotebookHierarchy(c *gin.Context) {
+	notebookID := c.Param("id")
+	if notebookID == "" {
+		c.JSON(http.StatusBadRequest, errors.Validation("Notebook ID is required", nil))
+		return
+	}
+
+	tenantID := c.Query("tenant_id")
+	if tenantID == "" {
+		c.JSON(http.StatusBadRequest, errors.Validation("Tenant ID is required", nil))
+		return
+	}
+
+	hierarchy, err := h.notebookService.GetNotebookHierarchy(c.Request.Context(), notebookID, tenantID)
+	if err != nil {
+		h.logger.Error("Failed to get notebook hierarchy",
+			zap.String("notebook_id", notebookID),
+			zap.String("tenant_id", tenantID),
+			zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, hierarchy)
+}
+
+// GetDocumentsRecursive gets all documents from notebook and sub-notebooks
+// @Summary Get documents recursively
+// @Description Get all documents from notebook and all sub-notebooks
+// @Tags internal-notebooks
+// @Accept json
+// @Produce json
+// @Param id path string true "Notebook ID"
+// @Param tenant_id query string true "Tenant ID"
+// @Success 200 {object} models.NotebookDocumentsResponse
+// @Failure 400 {object} errors.APIError
+// @Failure 404 {object} errors.APIError
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/internal/notebooks/{id}/documents/recursive [get]
+func (h *NotebookHandler) GetDocumentsRecursive(c *gin.Context) {
+	notebookID := c.Param("id")
+	if notebookID == "" {
+		c.JSON(http.StatusBadRequest, errors.Validation("Notebook ID is required", nil))
+		return
+	}
+
+	tenantID := c.Query("tenant_id")
+	if tenantID == "" {
+		c.JSON(http.StatusBadRequest, errors.Validation("Tenant ID is required", nil))
+		return
+	}
+
+	documents, err := h.notebookService.GetDocumentsRecursive(c.Request.Context(), notebookID, tenantID)
+	if err != nil {
+		h.logger.Error("Failed to get documents recursively",
+			zap.String("notebook_id", notebookID),
+			zap.String("tenant_id", tenantID),
+			zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"notebook_id": notebookID,
+		"documents":   documents,
+		"total":       len(documents),
+	})
+}
+
+// GetSubNotebooks gets sub-notebook IDs for a parent notebook
+// @Summary Get sub-notebooks
+// @Description Get IDs of all sub-notebooks for a parent notebook
+// @Tags internal-notebooks
+// @Accept json
+// @Produce json
+// @Param id path string true "Parent Notebook ID"
+// @Param tenant_id query string true "Tenant ID"
+// @Success 200 {object} models.SubNotebooksResponse
+// @Failure 400 {object} errors.APIError
+// @Failure 404 {object} errors.APIError
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/internal/notebooks/{id}/sub-notebooks [get]
+func (h *NotebookHandler) GetSubNotebooks(c *gin.Context) {
+	notebookID := c.Param("id")
+	if notebookID == "" {
+		c.JSON(http.StatusBadRequest, errors.Validation("Notebook ID is required", nil))
+		return
+	}
+
+	tenantID := c.Query("tenant_id")
+	if tenantID == "" {
+		c.JSON(http.StatusBadRequest, errors.Validation("Tenant ID is required", nil))
+		return
+	}
+
+	subNotebookIDs, err := h.notebookService.GetSubNotebookIDs(c.Request.Context(), notebookID, tenantID)
+	if err != nil {
+		h.logger.Error("Failed to get sub-notebooks",
+			zap.String("notebook_id", notebookID),
+			zap.String("tenant_id", tenantID),
+			zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"parent_notebook_id": notebookID,
+		"sub_notebook_ids":   subNotebookIDs,
+		"total":              len(subNotebookIDs),
+	})
+}
+
+// GetNotebookDocuments gets documents for a specific notebook (non-recursive)
+// @Summary Get notebook documents
+// @Description Get documents for a specific notebook (flat, no recursion)
+// @Tags internal-notebooks
+// @Accept json
+// @Produce json
+// @Param id path string true "Notebook ID"
+// @Param tenant_id query string true "Tenant ID"
+// @Success 200 {object} models.NotebookDocumentsResponse
+// @Failure 400 {object} errors.APIError
+// @Failure 404 {object} errors.APIError
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/internal/notebooks/{id}/documents [get]
+func (h *NotebookHandler) GetNotebookDocuments(c *gin.Context) {
+	notebookID := c.Param("id")
+	if notebookID == "" {
+		c.JSON(http.StatusBadRequest, errors.Validation("Notebook ID is required", nil))
+		return
+	}
+
+	tenantID := c.Query("tenant_id")
+	if tenantID == "" {
+		c.JSON(http.StatusBadRequest, errors.Validation("Tenant ID is required", nil))
+		return
+	}
+
+	documents, err := h.notebookService.GetNotebookDocuments(c.Request.Context(), notebookID, tenantID)
+	if err != nil {
+		h.logger.Error("Failed to get notebook documents",
+			zap.String("notebook_id", notebookID),
+			zap.String("tenant_id", tenantID),
+			zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"notebook_id": notebookID,
+		"documents":   documents,
+		"total":       len(documents),
+	})
+}

--- a/internal/handlers/production.go
+++ b/internal/handlers/production.go
@@ -1,0 +1,959 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/Tributary-ai-services/aether-be/internal/logger"
+	"github.com/Tributary-ai-services/aether-be/internal/middleware"
+	"github.com/Tributary-ai-services/aether-be/internal/models"
+	"github.com/Tributary-ai-services/aether-be/internal/services"
+	"github.com/Tributary-ai-services/aether-be/pkg/errors"
+)
+
+// extractBearerToken extracts the Bearer token from the Authorization header
+func extractBearerToken(c *gin.Context) string {
+	authHeader := c.GetHeader("Authorization")
+	if authHeader == "" {
+		return ""
+	}
+
+	// Expected format: "Bearer <token>"
+	parts := strings.SplitN(authHeader, " ", 2)
+	if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
+		return ""
+	}
+
+	return parts[1]
+}
+
+// ProductionHandler handles production-related HTTP requests
+type ProductionHandler struct {
+	productionService *services.ProductionService
+	userService       *services.UserService
+	teamService       *services.TeamService
+	logger            *logger.Logger
+}
+
+// NewProductionHandler creates a new production handler
+func NewProductionHandler(
+	productionService *services.ProductionService,
+	userService *services.UserService,
+	teamService *services.TeamService,
+	log *logger.Logger,
+) *ProductionHandler {
+	return &ProductionHandler{
+		productionService: productionService,
+		userService:       userService,
+		teamService:       teamService,
+		logger:            log.WithService("production_handler"),
+	}
+}
+
+// GetNotebookProducers returns available producer agents for a notebook
+// @Summary Get notebook producers
+// @Description Get available producer agents for a notebook
+// @Tags productions
+// @Produce json
+// @Security Bearer
+// @Param id path string true "Notebook ID"
+// @Success 200 {object} []models.AgentResponse
+// @Failure 401 {object} errors.APIError
+// @Failure 404 {object} errors.APIError
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/notebooks/{id}/producers [get]
+func (h *ProductionHandler) GetNotebookProducers(c *gin.Context) {
+	notebookID := c.Param("id")
+	if notebookID == "" {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Notebook ID is required"))
+		return
+	}
+
+	// Resolve user
+	userID, err := ensureUserExists(c, h.userService, h.logger)
+	if err != nil {
+		h.logger.Error("Failed to resolve user", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	// Get space context from middleware
+	spaceContext, err := middleware.GetSpaceContext(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Space context is required"))
+		return
+	}
+
+	// Get auth token for agent-builder API calls
+	authToken := extractBearerToken(c)
+
+	producers, err := h.productionService.GetNotebookProducers(c.Request.Context(), notebookID, userID, authToken, spaceContext)
+	if err != nil {
+		h.logger.Error("Failed to get notebook producers", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, producers)
+}
+
+// ExecuteProducer executes a producer agent on a notebook
+// @Summary Execute producer
+// @Description Execute a producer agent on a notebook to generate content
+// @Tags productions
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param id path string true "Notebook ID"
+// @Param agent_id path string true "Agent ID"
+// @Param request body models.ProducerExecuteRequest true "Execute request"
+// @Success 201 {object} models.ProducerExecuteResponse
+// @Failure 400 {object} errors.APIError
+// @Failure 401 {object} errors.APIError
+// @Failure 404 {object} errors.APIError
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/notebooks/{id}/producers/{agent_id}/execute [post]
+func (h *ProductionHandler) ExecuteProducer(c *gin.Context) {
+	notebookID := c.Param("id")
+	if notebookID == "" {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Notebook ID is required"))
+		return
+	}
+
+	agentID := c.Param("agent_id")
+	if agentID == "" {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Agent ID is required"))
+		return
+	}
+
+	// Resolve user
+	userID, err := ensureUserExists(c, h.userService, h.logger)
+	if err != nil {
+		h.logger.Error("Failed to resolve user", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	// Get user teams for access control
+	userTeams, err := h.getUserTeams(c, userID)
+	if err != nil {
+		h.logger.Warn("Failed to get user teams, using empty list", zap.Error(err))
+		userTeams = []string{}
+	}
+
+	// Get auth token
+	authToken := extractAuthToken(c)
+	if authToken == "" {
+		c.JSON(http.StatusUnauthorized, errors.Unauthorized("Authorization token is required"))
+		return
+	}
+
+	// Parse request body
+	var req models.ProducerExecuteRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		h.logger.Error("Invalid request payload", zap.Error(err))
+		c.JSON(http.StatusBadRequest, errors.Validation("Invalid request payload", err))
+		return
+	}
+
+	// Set agent ID from path parameter
+	req.AgentID = agentID
+
+	// Validate request
+	if err := validateStruct(&req); err != nil {
+		c.JSON(http.StatusBadRequest, errors.Validation("Validation failed", err))
+		return
+	}
+
+	// Get space context from middleware
+	spaceContext, err := middleware.GetSpaceContext(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Space context is required"))
+		return
+	}
+
+	// Execute producer
+	production, err := h.productionService.ExecuteProducer(c.Request.Context(), notebookID, req, userID, userTeams, authToken, spaceContext)
+	if err != nil {
+		h.logger.Error("Failed to execute producer", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	h.logger.Info("Producer executed successfully",
+		zap.String("production_id", production.ID),
+		zap.String("notebook_id", notebookID),
+		zap.String("agent_id", agentID),
+	)
+
+	c.JSON(http.StatusCreated, models.ProducerExecuteResponse{
+		Production: production,
+		Content:    production.Content,
+	})
+}
+
+// ListNotebookProductions lists productions for a notebook
+// @Summary List notebook productions
+// @Description List all productions for a notebook
+// @Tags productions
+// @Produce json
+// @Security Bearer
+// @Param id path string true "Notebook ID"
+// @Param limit query integer false "Limit (default 20, max 100)"
+// @Param offset query integer false "Offset (default 0)"
+// @Success 200 {object} models.ProductionListResponse
+// @Failure 401 {object} errors.APIError
+// @Failure 404 {object} errors.APIError
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/notebooks/{id}/productions [get]
+func (h *ProductionHandler) ListNotebookProductions(c *gin.Context) {
+	notebookID := c.Param("id")
+	if notebookID == "" {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Notebook ID is required"))
+		return
+	}
+
+	// Resolve user
+	userID, err := ensureUserExists(c, h.userService, h.logger)
+	if err != nil {
+		h.logger.Error("Failed to resolve user", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	// Get space context from middleware
+	spaceContext, err := middleware.GetSpaceContext(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Space context is required"))
+		return
+	}
+
+	// Parse pagination parameters
+	limit := 20
+	offset := 0
+
+	if limitStr := c.Query("limit"); limitStr != "" {
+		if val, err := strconv.Atoi(limitStr); err == nil && val > 0 && val <= 100 {
+			limit = val
+		}
+	}
+
+	if offsetStr := c.Query("offset"); offsetStr != "" {
+		if val, err := strconv.Atoi(offsetStr); err == nil && val >= 0 {
+			offset = val
+		}
+	}
+
+	productions, err := h.productionService.ListNotebookProductions(c.Request.Context(), notebookID, userID, spaceContext, limit, offset)
+	if err != nil {
+		h.logger.Error("Failed to list notebook productions", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, productions)
+}
+
+// GetProduction retrieves a production by ID
+// @Summary Get production
+// @Description Retrieve a production by ID
+// @Tags productions
+// @Produce json
+// @Security Bearer
+// @Param id path string true "Production ID"
+// @Success 200 {object} models.ProductionResponse
+// @Failure 401 {object} errors.APIError
+// @Failure 404 {object} errors.APIError
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/productions/{id} [get]
+func (h *ProductionHandler) GetProduction(c *gin.Context) {
+	productionID := c.Param("id")
+	if productionID == "" {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Production ID is required"))
+		return
+	}
+
+	// Resolve user
+	userID, err := ensureUserExists(c, h.userService, h.logger)
+	if err != nil {
+		h.logger.Error("Failed to resolve user", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	// Get space context from middleware
+	spaceContext, err := middleware.GetSpaceContext(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Space context is required"))
+		return
+	}
+
+	production, err := h.productionService.GetProductionByID(c.Request.Context(), productionID, userID, spaceContext)
+	if err != nil {
+		h.logger.Error("Failed to get production", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, production.ToResponse())
+}
+
+// GetProductionContent retrieves the content of a production
+// @Summary Get production content
+// @Description Retrieve the generated content of a production
+// @Tags productions
+// @Produce json
+// @Security Bearer
+// @Param id path string true "Production ID"
+// @Success 200 {object} map[string]string
+// @Failure 401 {object} errors.APIError
+// @Failure 404 {object} errors.APIError
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/productions/{id}/content [get]
+func (h *ProductionHandler) GetProductionContent(c *gin.Context) {
+	productionID := c.Param("id")
+	if productionID == "" {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Production ID is required"))
+		return
+	}
+
+	// Resolve user
+	userID, err := ensureUserExists(c, h.userService, h.logger)
+	if err != nil {
+		h.logger.Error("Failed to resolve user", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	// Get space context from middleware
+	spaceContext, err := middleware.GetSpaceContext(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Space context is required"))
+		return
+	}
+
+	content, err := h.productionService.GetProductionContent(c.Request.Context(), productionID, userID, spaceContext)
+	if err != nil {
+		h.logger.Error("Failed to get production content", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"content": content,
+	})
+}
+
+// DeleteProduction deletes a production
+// @Summary Delete production
+// @Description Delete a production and its stored content
+// @Tags productions
+// @Security Bearer
+// @Param id path string true "Production ID"
+// @Success 204
+// @Failure 401 {object} errors.APIError
+// @Failure 404 {object} errors.APIError
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/productions/{id} [delete]
+func (h *ProductionHandler) DeleteProduction(c *gin.Context) {
+	productionID := c.Param("id")
+	if productionID == "" {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Production ID is required"))
+		return
+	}
+
+	// Resolve user
+	userID, err := ensureUserExists(c, h.userService, h.logger)
+	if err != nil {
+		h.logger.Error("Failed to resolve user", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	// Get space context from middleware
+	spaceContext, err := middleware.GetSpaceContext(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Space context is required"))
+		return
+	}
+
+	err = h.productionService.DeleteProduction(c.Request.Context(), productionID, userID, spaceContext)
+	if err != nil {
+		h.logger.Error("Failed to delete production", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	h.logger.Info("Production deleted successfully", zap.String("production_id", productionID))
+	c.Status(http.StatusNoContent)
+}
+
+// GetProducerPreferences retrieves producer preferences for the current user
+// @Summary Get producer preferences
+// @Description Get producer preferences including pinned agents and settings
+// @Tags productions
+// @Produce json
+// @Security Bearer
+// @Success 200 {object} models.ProducerPreferences
+// @Failure 401 {object} errors.APIError
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/users/me/preferences/producers [get]
+func (h *ProductionHandler) GetProducerPreferences(c *gin.Context) {
+	// Resolve user
+	userID, err := ensureUserExists(c, h.userService, h.logger)
+	if err != nil {
+		h.logger.Error("Failed to resolve user", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	// Get user to access preferences
+	user, err := h.userService.GetUserByID(c.Request.Context(), userID)
+	if err != nil {
+		h.logger.Error("Failed to get user", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	// Extract producer preferences from user preferences
+	preferences := &models.ProducerPreferences{}
+	if user.Preferences != nil {
+		if producerPrefs, ok := user.Preferences["producers"]; ok {
+			if prefs, ok := producerPrefs.(map[string]interface{}); ok {
+				// Parse pinned
+				if pinned, ok := prefs["pinned"].(map[string]interface{}); ok {
+					preferences.Pinned = &models.PinnedProducers{}
+					if global, ok := pinned["global"].([]interface{}); ok {
+						for _, id := range global {
+							if idStr, ok := id.(string); ok {
+								preferences.Pinned.Global = append(preferences.Pinned.Global, idStr)
+							}
+						}
+					}
+					if bySpace, ok := pinned["by_space"].(map[string]interface{}); ok {
+						preferences.Pinned.BySpace = make(map[string][]string)
+						for spaceID, agents := range bySpace {
+							if agentList, ok := agents.([]interface{}); ok {
+								for _, agent := range agentList {
+									if agentStr, ok := agent.(string); ok {
+										preferences.Pinned.BySpace[spaceID] = append(preferences.Pinned.BySpace[spaceID], agentStr)
+									}
+								}
+							}
+						}
+					}
+					if byNotebook, ok := pinned["by_notebook"].(map[string]interface{}); ok {
+						preferences.Pinned.ByNotebook = make(map[string][]string)
+						for notebookID, agents := range byNotebook {
+							if agentList, ok := agents.([]interface{}); ok {
+								for _, agent := range agentList {
+									if agentStr, ok := agent.(string); ok {
+										preferences.Pinned.ByNotebook[notebookID] = append(preferences.Pinned.ByNotebook[notebookID], agentStr)
+									}
+								}
+							}
+						}
+					}
+				}
+				// Parse order (custom ordering for drag-and-drop)
+				if order, ok := prefs["order"].(map[string]interface{}); ok {
+					preferences.Order = &models.OrderedProducers{}
+					if global, ok := order["global"].([]interface{}); ok {
+						for _, id := range global {
+							if idStr, ok := id.(string); ok {
+								preferences.Order.Global = append(preferences.Order.Global, idStr)
+							}
+						}
+					}
+					if bySpace, ok := order["by_space"].(map[string]interface{}); ok {
+						preferences.Order.BySpace = make(map[string][]string)
+						for spaceID, agents := range bySpace {
+							if agentList, ok := agents.([]interface{}); ok {
+								for _, agent := range agentList {
+									if agentStr, ok := agent.(string); ok {
+										preferences.Order.BySpace[spaceID] = append(preferences.Order.BySpace[spaceID], agentStr)
+									}
+								}
+							}
+						}
+					}
+					if byNotebook, ok := order["by_notebook"].(map[string]interface{}); ok {
+						preferences.Order.ByNotebook = make(map[string][]string)
+						for notebookID, agents := range byNotebook {
+							if agentList, ok := agents.([]interface{}); ok {
+								for _, agent := range agentList {
+									if agentStr, ok := agent.(string); ok {
+										preferences.Order.ByNotebook[notebookID] = append(preferences.Order.ByNotebook[notebookID], agentStr)
+									}
+								}
+							}
+						}
+					}
+				}
+				// Parse recent
+				if recent, ok := prefs["recent"].([]interface{}); ok {
+					for _, id := range recent {
+						if idStr, ok := id.(string); ok {
+							preferences.Recent = append(preferences.Recent, idStr)
+						}
+					}
+				}
+				// Parse settings
+				if settings, ok := prefs["settings"].(map[string]interface{}); ok {
+					preferences.Settings = &models.ProducerSettingsPrefs{}
+					if defaultFormat, ok := settings["default_format"].(string); ok {
+						preferences.Settings.DefaultFormat = models.ProductionFormat(defaultFormat)
+					}
+					if defaultType, ok := settings["default_type"].(string); ok {
+						preferences.Settings.DefaultType = models.ProductionType(defaultType)
+					}
+				}
+			}
+		}
+	}
+
+	c.JSON(http.StatusOK, preferences)
+}
+
+// UpdateProducerPreferences updates producer preferences for the current user
+// @Summary Update producer preferences
+// @Description Update producer preferences including pin/unpin agents and settings
+// @Tags productions
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param request body models.UpdateProducerPreferencesRequest true "Update request"
+// @Success 200 {object} models.ProducerPreferences
+// @Failure 400 {object} errors.APIError
+// @Failure 401 {object} errors.APIError
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/users/me/preferences/producers [patch]
+func (h *ProductionHandler) UpdateProducerPreferences(c *gin.Context) {
+	// Resolve user
+	userID, err := ensureUserExists(c, h.userService, h.logger)
+	if err != nil {
+		h.logger.Error("Failed to resolve user", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	// Parse request body
+	var req models.UpdateProducerPreferencesRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		h.logger.Error("Invalid request payload", zap.Error(err))
+		c.JSON(http.StatusBadRequest, errors.Validation("Invalid request payload", err))
+		return
+	}
+
+	// Get current user to update preferences
+	user, err := h.userService.GetUserByID(c.Request.Context(), userID)
+	if err != nil {
+		h.logger.Error("Failed to get user", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	// Initialize preferences if nil
+	if user.Preferences == nil {
+		user.Preferences = make(map[string]interface{})
+	}
+
+	// Get or create producer preferences
+	var producerPrefs map[string]interface{}
+	if prefs, ok := user.Preferences["producers"].(map[string]interface{}); ok {
+		producerPrefs = prefs
+	} else {
+		producerPrefs = make(map[string]interface{})
+	}
+
+	// Get or create pinned preferences
+	var pinnedPrefs map[string]interface{}
+	if pinned, ok := producerPrefs["pinned"].(map[string]interface{}); ok {
+		pinnedPrefs = pinned
+	} else {
+		pinnedPrefs = map[string]interface{}{
+			"global":      []string{},
+			"by_space":    map[string]interface{}{},
+			"by_notebook": map[string]interface{}{},
+		}
+	}
+
+	// Handle pin/unpin global
+	if req.PinGlobal != nil {
+		globalPins := getStringSlice(pinnedPrefs["global"])
+		if !contains(globalPins, *req.PinGlobal) {
+			globalPins = append(globalPins, *req.PinGlobal)
+		}
+		pinnedPrefs["global"] = globalPins
+	}
+	if req.UnpinGlobal != nil {
+		globalPins := getStringSlice(pinnedPrefs["global"])
+		pinnedPrefs["global"] = removeFromSlice(globalPins, *req.UnpinGlobal)
+	}
+
+	// Handle pin/unpin to space
+	if req.PinToSpace != nil && req.SpaceID != "" {
+		bySpace := getMapStringSlice(pinnedPrefs["by_space"])
+		spacePins := bySpace[req.SpaceID]
+		if !contains(spacePins, *req.PinToSpace) {
+			spacePins = append(spacePins, *req.PinToSpace)
+		}
+		bySpace[req.SpaceID] = spacePins
+		pinnedPrefs["by_space"] = bySpace
+	}
+	if req.UnpinFromSpace != nil && req.SpaceID != "" {
+		bySpace := getMapStringSlice(pinnedPrefs["by_space"])
+		bySpace[req.SpaceID] = removeFromSlice(bySpace[req.SpaceID], *req.UnpinFromSpace)
+		pinnedPrefs["by_space"] = bySpace
+	}
+
+	// Handle pin/unpin to notebook
+	if req.PinToNotebook != nil && req.NotebookID != "" {
+		byNotebook := getMapStringSlice(pinnedPrefs["by_notebook"])
+		notebookPins := byNotebook[req.NotebookID]
+		if !contains(notebookPins, *req.PinToNotebook) {
+			notebookPins = append(notebookPins, *req.PinToNotebook)
+		}
+		byNotebook[req.NotebookID] = notebookPins
+		pinnedPrefs["by_notebook"] = byNotebook
+	}
+	if req.UnpinFromNotebook != nil && req.NotebookID != "" {
+		byNotebook := getMapStringSlice(pinnedPrefs["by_notebook"])
+		byNotebook[req.NotebookID] = removeFromSlice(byNotebook[req.NotebookID], *req.UnpinFromNotebook)
+		pinnedPrefs["by_notebook"] = byNotebook
+	}
+
+	// Get or create order preferences
+	var orderPrefs map[string]interface{}
+	if order, ok := producerPrefs["order"].(map[string]interface{}); ok {
+		orderPrefs = order
+	} else {
+		orderPrefs = map[string]interface{}{
+			"global":      []string{},
+			"by_space":    map[string]interface{}{},
+			"by_notebook": map[string]interface{}{},
+		}
+	}
+
+	// Handle set order global
+	if len(req.SetOrderGlobal) > 0 {
+		orderPrefs["global"] = req.SetOrderGlobal
+	}
+
+	// Handle set order for space
+	if len(req.SetOrderForSpace) > 0 && req.SpaceID != "" {
+		bySpace := getMapStringSlice(orderPrefs["by_space"])
+		bySpace[req.SpaceID] = req.SetOrderForSpace
+		orderPrefs["by_space"] = bySpace
+	}
+
+	// Handle set order for notebook
+	if len(req.SetOrderForNotebook) > 0 && req.NotebookID != "" {
+		byNotebook := getMapStringSlice(orderPrefs["by_notebook"])
+		byNotebook[req.NotebookID] = req.SetOrderForNotebook
+		orderPrefs["by_notebook"] = byNotebook
+	}
+
+	// Handle settings updates
+	var settingsPrefs map[string]interface{}
+	if settings, ok := producerPrefs["settings"].(map[string]interface{}); ok {
+		settingsPrefs = settings
+	} else {
+		settingsPrefs = make(map[string]interface{})
+	}
+	if req.DefaultFormat != nil {
+		settingsPrefs["default_format"] = string(*req.DefaultFormat)
+	}
+	if req.DefaultType != nil {
+		settingsPrefs["default_type"] = string(*req.DefaultType)
+	}
+
+	// Update producer preferences
+	producerPrefs["pinned"] = pinnedPrefs
+	producerPrefs["order"] = orderPrefs
+	producerPrefs["settings"] = settingsPrefs
+	user.Preferences["producers"] = producerPrefs
+
+	// Save user preferences
+	updateReq := models.UserUpdateRequest{
+		Preferences: user.Preferences,
+	}
+	_, err = h.userService.UpdateUser(c.Request.Context(), userID, updateReq)
+	if err != nil {
+		h.logger.Error("Failed to update user preferences", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	h.logger.Info("Producer preferences updated successfully", zap.String("user_id", userID))
+
+	// Return updated preferences
+	h.GetProducerPreferences(c)
+}
+
+// Helper functions
+
+func getStringSlice(v interface{}) []string {
+	if v == nil {
+		return []string{}
+	}
+	switch val := v.(type) {
+	case []string:
+		return val
+	case []interface{}:
+		result := make([]string, 0, len(val))
+		for _, item := range val {
+			if str, ok := item.(string); ok {
+				result = append(result, str)
+			}
+		}
+		return result
+	default:
+		return []string{}
+	}
+}
+
+func getMapStringSlice(v interface{}) map[string][]string {
+	result := make(map[string][]string)
+	if v == nil {
+		return result
+	}
+	switch val := v.(type) {
+	case map[string][]string:
+		return val
+	case map[string]interface{}:
+		for k, v := range val {
+			result[k] = getStringSlice(v)
+		}
+		return result
+	default:
+		return result
+	}
+}
+
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+func removeFromSlice(slice []string, item string) []string {
+	result := make([]string, 0, len(slice))
+	for _, s := range slice {
+		if s != item {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// BulkDeleteProductions deletes multiple productions
+// @Summary Bulk delete productions
+// @Description Delete multiple productions and their stored content
+// @Tags productions
+// @Accept json
+// @Security Bearer
+// @Param request body models.BulkDeleteProductionsRequest true "Bulk delete request"
+// @Success 200 {object} models.BulkDeleteProductionsResponse
+// @Failure 400 {object} errors.APIError
+// @Failure 401 {object} errors.APIError
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/productions/bulk-delete [post]
+func (h *ProductionHandler) BulkDeleteProductions(c *gin.Context) {
+	// Resolve user
+	userID, err := ensureUserExists(c, h.userService, h.logger)
+	if err != nil {
+		h.logger.Error("Failed to resolve user", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	// Get space context from middleware
+	spaceContext, err := middleware.GetSpaceContext(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Space context is required"))
+		return
+	}
+
+	// Parse request body
+	var req models.BulkDeleteProductionsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		h.logger.Error("Invalid request payload", zap.Error(err))
+		c.JSON(http.StatusBadRequest, errors.Validation("Invalid request payload", err))
+		return
+	}
+
+	if len(req.ProductionIDs) == 0 {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("At least one production ID is required"))
+		return
+	}
+
+	// Limit bulk delete to 100 items at a time
+	if len(req.ProductionIDs) > 100 {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Cannot delete more than 100 productions at a time"))
+		return
+	}
+
+	// Delete each production and track results
+	deleted := []string{}
+	failed := []models.BulkDeleteFailure{}
+
+	for _, productionID := range req.ProductionIDs {
+		err := h.productionService.DeleteProduction(c.Request.Context(), productionID, userID, spaceContext)
+		if err != nil {
+			h.logger.Warn("Failed to delete production in bulk operation",
+				zap.String("production_id", productionID),
+				zap.Error(err))
+			failed = append(failed, models.BulkDeleteFailure{
+				ProductionID: productionID,
+				Error:        err.Error(),
+			})
+		} else {
+			deleted = append(deleted, productionID)
+		}
+	}
+
+	h.logger.Info("Bulk delete productions completed",
+		zap.Int("deleted_count", len(deleted)),
+		zap.Int("failed_count", len(failed)),
+		zap.String("user_id", userID),
+	)
+
+	c.JSON(http.StatusOK, models.BulkDeleteProductionsResponse{
+		Deleted: deleted,
+		Failed:  failed,
+	})
+}
+
+// getUserTeams retrieves team IDs for a user for access control purposes
+func (h *ProductionHandler) getUserTeams(c *gin.Context, userID string) ([]string, error) {
+	teamIDs, err := h.teamService.GetUserTeamIDs(c.Request.Context(), userID)
+	if err != nil {
+		h.logger.Error("Failed to get user team IDs",
+			zap.String("user_id", userID),
+			zap.Error(err))
+		// Return empty slice rather than failing the request - user may not be in any teams
+		return []string{}, nil
+	}
+
+	h.logger.Debug("Retrieved user teams for production access control",
+		zap.String("user_id", userID),
+		zap.Int("team_count", len(teamIDs)))
+
+	return teamIDs, nil
+}
+
+// NotebookChatRequest represents a chat request for a notebook
+type NotebookChatRequest struct {
+	Message string                   `json:"message" binding:"required"`
+	History []NotebookChatMessage    `json:"history,omitempty"`
+}
+
+// NotebookChatMessage represents a message in the chat history
+type NotebookChatMessage struct {
+	Role    string `json:"role"`    // "user" or "assistant"
+	Content string `json:"content"`
+}
+
+// NotebookChatResponse represents the response from notebook chat
+type NotebookChatResponse struct {
+	Message   string `json:"message"`
+	AgentID   string `json:"agent_id"`
+	AgentName string `json:"agent_name"`
+}
+
+// NotebookChat handles chat requests for a notebook using the internal Notebook Chat Assistant
+// @Summary Chat with notebook
+// @Description Send a message to chat about notebook content using the AI assistant
+// @Tags notebooks
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param id path string true "Notebook ID"
+// @Param request body NotebookChatRequest true "Chat request"
+// @Success 200 {object} NotebookChatResponse
+// @Failure 400 {object} errors.APIError
+// @Failure 401 {object} errors.APIError
+// @Failure 404 {object} errors.APIError
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/notebooks/{id}/chat [post]
+func (h *ProductionHandler) NotebookChat(c *gin.Context) {
+	notebookID := c.Param("id")
+	if notebookID == "" {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Notebook ID is required"))
+		return
+	}
+
+	// Resolve user
+	userID, err := ensureUserExists(c, h.userService, h.logger)
+	if err != nil {
+		h.logger.Error("Failed to resolve user", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	// Get auth token
+	authToken := extractAuthToken(c)
+	if authToken == "" {
+		c.JSON(http.StatusUnauthorized, errors.Unauthorized("Authorization token is required"))
+		return
+	}
+
+	// Parse request body
+	var req NotebookChatRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		h.logger.Error("Invalid request payload", zap.Error(err))
+		c.JSON(http.StatusBadRequest, errors.Validation("Invalid request payload", err))
+		return
+	}
+
+	// Get space context from middleware
+	spaceContext, err := middleware.GetSpaceContext(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, errors.BadRequest("Space context is required"))
+		return
+	}
+
+	// Build conversation history for the agent
+	var conversationHistory []models.ConversationMessage
+	for _, msg := range req.History {
+		conversationHistory = append(conversationHistory, models.ConversationMessage{
+			Role:    msg.Role,
+			Content: msg.Content,
+		})
+	}
+
+	// Execute chat using the production service
+	response, err := h.productionService.ExecuteNotebookChat(
+		c.Request.Context(),
+		notebookID,
+		req.Message,
+		conversationHistory,
+		userID,
+		authToken,
+		spaceContext,
+	)
+	if err != nil {
+		h.logger.Error("Failed to execute notebook chat", zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	h.logger.Info("Notebook chat completed",
+		zap.String("notebook_id", notebookID),
+		zap.String("user_id", userID),
+	)
+
+	c.JSON(http.StatusOK, NotebookChatResponse{
+		Message:   response.Content,
+		AgentID:   NotebookChatAssistantID,
+		AgentName: "Notebook Chat Assistant",
+	})
+}

--- a/internal/handlers/routes.go
+++ b/internal/handlers/routes.go
@@ -41,6 +41,7 @@ type APIServer struct {
 	DatabaseHandler      *DatabaseHandler
 	SavedQueryHandler    *SavedQueryHandler
 	AIPlaygroundHandler  *AIPlaygroundHandler
+	ProductionHandler    *ProductionHandler
 	SpaceService         *services.SpaceContextService
 	Metrics              *metrics.Metrics
 	logger               *logger.Logger
@@ -145,6 +146,10 @@ func NewAPIServer(
 	aiPlaygroundService := services.NewAIPlaygroundService(neo4j, &cfg.Router, agentService, workflowService, log)
 	aiPlaygroundHandler := NewAIPlaygroundHandler(aiPlaygroundService, userService, teamService, log)
 
+	// Initialize Production service and handler
+	productionService := services.NewProductionService(neo4j, storageService, agentService, notebookService, teamService, spaceService, audiModalClient, log)
+	productionHandler := NewProductionHandler(productionService, userService, teamService, log)
+
 	// Initialize router handler (may be nil if disabled)
 	routerHandler, err := NewRouterHandler(&cfg.Router, log)
 	if err != nil {
@@ -192,6 +197,7 @@ func NewAPIServer(
 		DatabaseHandler:      databaseHandler,
 		SavedQueryHandler:    savedQueryHandler,
 		AIPlaygroundHandler:  aiPlaygroundHandler,
+		ProductionHandler:    productionHandler,
 		SpaceService:         spaceContextService,
 		Metrics:              metricsInstance,
 		logger:               log.WithService("api_server"),
@@ -235,6 +241,10 @@ func (s *APIServer) setupRoutes(keycloakClient *auth.KeycloakClient) {
 		users.DELETE("/me/onboarding", s.UserHandler.ResetTutorial)
 		users.GET("/search", s.UserHandler.SearchUsers)
 		users.GET("/:id", s.UserHandler.GetUserByID)
+
+		// Producer preferences
+		users.GET("/me/preferences/producers", s.ProductionHandler.GetProducerPreferences)
+		users.PATCH("/me/preferences/producers", s.ProductionHandler.UpdateProducerPreferences)
 	}
 
 	// Notebook routes
@@ -257,6 +267,16 @@ func (s *APIServer) setupRoutes(keycloakClient *auth.KeycloakClient) {
 		notebooks.POST("/:id/vector-search/text", s.VectorSearchHandler.TextSearch)
 		notebooks.POST("/:id/vector-search/hybrid", s.VectorSearchHandler.HybridSearch)
 		notebooks.GET("/:id/vector-search/info", s.VectorSearchHandler.GetVectorSearchInfo)
+
+		// Producer agents for notebook
+		notebooks.GET("/:id/producers", s.ProductionHandler.GetNotebookProducers)
+		notebooks.POST("/:id/producers/:agent_id/execute", s.ProductionHandler.ExecuteProducer)
+
+		// Notebook chat - uses internal Notebook Chat Assistant agent
+		notebooks.POST("/:id/chat", s.ProductionHandler.NotebookChat)
+
+		// Productions (artifacts) within notebook
+		notebooks.GET("/:id/productions", s.ProductionHandler.ListNotebookProductions)
 	}
 
 	// Document routes
@@ -279,6 +299,17 @@ func (s *APIServer) setupRoutes(keycloakClient *auth.KeycloakClient) {
 		documents.GET("/:id/url", s.DocumentHandler.GetDocumentURL)
 		documents.GET("/:id/analysis", s.DocumentHandler.GetDocumentAnalysis)
 		documents.GET("/:id/text", s.DocumentHandler.GetDocumentExtractedText)
+	}
+
+	// Production routes - standalone CRUD for productions
+	productions := api.Group("/productions")
+	productions.Use(middleware.SpaceContextMiddleware(s.SpaceService, s.logger))
+	productions.Use(middleware.RequireSpaceContext(s.logger))
+	{
+		productions.GET("/:id", s.ProductionHandler.GetProduction)
+		productions.GET("/:id/content", s.ProductionHandler.GetProductionContent)
+		productions.DELETE("/:id", s.ProductionHandler.DeleteProduction)
+		productions.POST("/bulk-delete", s.ProductionHandler.BulkDeleteProductions)
 	}
 
 	// Chunk routes - file-specific chunks
@@ -353,6 +384,20 @@ func (s *APIServer) setupRoutes(keycloakClient *auth.KeycloakClient) {
 		internalAgents.GET("", s.AgentHandler.ListInternalAgents)
 		internalAgents.GET("/:id", s.AgentHandler.GetInternalAgent)
 		internalAgents.POST("/:id/execute", s.AgentHandler.ExecuteInternalAgent)
+	}
+
+	// Internal notebook routes - for service-to-service communication (agent-builder, etc.)
+	// These routes bypass space context middleware for internal service calls
+	internalNotebooks := api.Group("/internal/notebooks")
+	{
+		// Get notebook hierarchy with optional sub-notebooks
+		internalNotebooks.GET("/:id/hierarchy", s.NotebookHandler.GetNotebookHierarchy)
+		// Get all documents recursively from notebook and sub-notebooks
+		internalNotebooks.GET("/:id/documents/recursive", s.NotebookHandler.GetDocumentsRecursive)
+		// Get sub-notebook IDs for a parent notebook
+		internalNotebooks.GET("/:id/sub-notebooks", s.NotebookHandler.GetSubNotebooks)
+		// Get documents for specific notebook (flat, no recursion)
+		internalNotebooks.GET("/:id/documents", s.NotebookHandler.GetNotebookDocuments)
 	}
 
 	// Agent routes - with space context for multi-tenancy

--- a/internal/models/production.go
+++ b/internal/models/production.go
@@ -1,0 +1,360 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ProductionStatus represents the status of a production
+type ProductionStatus string
+
+const (
+	ProductionStatusProcessing ProductionStatus = "processing"
+	ProductionStatusCompleted  ProductionStatus = "completed"
+	ProductionStatusFailed     ProductionStatus = "failed"
+)
+
+// ProductionType represents the type of production
+type ProductionType string
+
+const (
+	ProductionTypeSummary ProductionType = "summary"
+	ProductionTypeQA      ProductionType = "qa"
+	ProductionTypeOutline ProductionType = "outline"
+	ProductionTypeInsight ProductionType = "insight"
+	ProductionTypeCustom  ProductionType = "custom"
+)
+
+// ProductionFormat represents the output format of a production
+type ProductionFormat string
+
+const (
+	ProductionFormatMarkdown ProductionFormat = "markdown"
+	ProductionFormatHTML     ProductionFormat = "html"
+	ProductionFormatJSON     ProductionFormat = "json"
+	ProductionFormatText     ProductionFormat = "text"
+)
+
+// Production represents a generated artifact from a producer agent
+type Production struct {
+	// Identity
+	ID    string `json:"id" validate:"required,uuid"`
+	Title string `json:"title" validate:"required,min=1,max=255"`
+
+	// Production type and format
+	Type   ProductionType   `json:"type" validate:"required,oneof=summary qa outline insight custom"`
+	Format ProductionFormat `json:"format" validate:"required,oneof=markdown html json text"`
+	Status ProductionStatus `json:"status" validate:"required,oneof=processing completed failed"`
+
+	// Agent that created this production
+	AgentID        string `json:"agent_id" validate:"required,uuid"`
+	AgentBuilderID string `json:"agent_builder_id,omitempty" validate:"omitempty,uuid"`
+
+	// Notebook association
+	NotebookID string `json:"notebook_id" validate:"required,uuid"`
+
+	// Owner and multi-tenancy
+	UserID    string    `json:"user_id" validate:"required,uuid"`
+	SpaceType SpaceType `json:"space_type" validate:"required,oneof=personal organization"`
+	SpaceID   string    `json:"space_id" validate:"required"`
+	TenantID  string    `json:"tenant_id" validate:"required"`
+
+	// S3 storage
+	StorageBucket string `json:"storage_bucket,omitempty"`
+	StorageKey    string `json:"storage_key,omitempty"`
+	SizeBytes     int64  `json:"size_bytes"`
+
+	// Execution metrics
+	ExecutionID    string  `json:"execution_id,omitempty"`
+	TokensUsed     int     `json:"tokens_used"`
+	CostUSD        float64 `json:"cost_usd"`
+	ResponseTimeMs int     `json:"response_time_ms"`
+
+	// Error handling
+	ErrorMessage string `json:"error_message,omitempty"`
+
+	// Source documents (document IDs used to generate this production)
+	SourceDocuments []string `json:"source_documents,omitempty"`
+
+	// Search text for full-text search
+	SearchText string `json:"search_text,omitempty"`
+
+	// Timestamps
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// ProductionCreateRequest represents a request to create/execute a production
+type ProductionCreateRequest struct {
+	Title           string           `json:"title" validate:"required,safe_string,min=1,max=255"`
+	Type            ProductionType   `json:"type" validate:"required,oneof=summary qa outline insight custom"`
+	Format          ProductionFormat `json:"format" validate:"required,oneof=markdown html json text"`
+	SourceDocuments []string         `json:"source_documents,omitempty" validate:"dive,uuid"`
+
+	// Optional context/parameters for the producer agent
+	Context map[string]interface{} `json:"context,omitempty"`
+}
+
+// ProductionUpdateRequest represents a request to update a production
+type ProductionUpdateRequest struct {
+	Title  *string          `json:"title,omitempty" validate:"omitempty,safe_string,min=1,max=255"`
+	Status *ProductionStatus `json:"status,omitempty" validate:"omitempty,oneof=processing completed failed"`
+}
+
+// ProductionResponse represents a production response
+type ProductionResponse struct {
+	ID              string           `json:"id"`
+	Title           string           `json:"title"`
+	Type            ProductionType   `json:"type"`
+	Format          ProductionFormat `json:"format"`
+	Status          ProductionStatus `json:"status"`
+	AgentID         string           `json:"agentId"`
+	AgentBuilderID  string           `json:"agentBuilderId,omitempty"`
+	NotebookID      string           `json:"notebookId"`
+	UserID          string           `json:"userId"`
+	SpaceType       SpaceType        `json:"spaceType"`
+	SpaceID         string           `json:"spaceId"`
+	SizeBytes       int64            `json:"sizeBytes"`
+	ExecutionID     string           `json:"executionId,omitempty"`
+	TokensUsed      int              `json:"tokensUsed"`
+	CostUSD         float64          `json:"costUsd"`
+	ResponseTimeMs  int              `json:"responseTimeMs"`
+	ErrorMessage    string           `json:"errorMessage,omitempty"`
+	SourceDocuments []string         `json:"sourceDocuments,omitempty"`
+	CreatedAt       time.Time        `json:"createdAt"`
+	UpdatedAt       time.Time        `json:"updatedAt"`
+
+	// Optional related data
+	Agent    *AgentResponse    `json:"agent,omitempty"`
+	Notebook *NotebookResponse `json:"notebook,omitempty"`
+	Owner    *PublicUserResponse `json:"owner,omitempty"`
+
+	// Content (populated when fetching single production with content)
+	Content string `json:"content,omitempty"`
+}
+
+// ProductionListResponse represents a paginated list of productions
+type ProductionListResponse struct {
+	Productions []*ProductionResponse `json:"productions"`
+	Total       int                   `json:"total"`
+	Limit       int                   `json:"limit"`
+	Offset      int                   `json:"offset"`
+	HasMore     bool                  `json:"hasMore"`
+}
+
+// ProductionSearchRequest represents a production search request
+type ProductionSearchRequest struct {
+	Query      string           `json:"query,omitempty" validate:"omitempty,safe_string,min=2,max=100"`
+	NotebookID string           `json:"notebook_id,omitempty" validate:"omitempty,uuid"`
+	AgentID    string           `json:"agent_id,omitempty" validate:"omitempty,uuid"`
+	Type       ProductionType   `json:"type,omitempty" validate:"omitempty,oneof=summary qa outline insight custom"`
+	Status     ProductionStatus `json:"status,omitempty" validate:"omitempty,oneof=processing completed failed"`
+	Limit      int              `json:"limit,omitempty" validate:"omitempty,min=1,max=100"`
+	Offset     int              `json:"offset,omitempty" validate:"omitempty,min=0"`
+}
+
+// ProducerExecuteRequest represents a request to execute a producer agent
+type ProducerExecuteRequest struct {
+	AgentID         string           `json:"agent_id" validate:"required,uuid"`
+	Title           string           `json:"title" validate:"required,safe_string,min=1,max=255"`
+	Type            ProductionType   `json:"type" validate:"required,oneof=summary qa outline insight custom"`
+	Format          ProductionFormat `json:"format" validate:"required,oneof=markdown html json text"`
+	SourceDocuments []string         `json:"source_documents,omitempty" validate:"dive,uuid"`
+	Context         map[string]interface{} `json:"context,omitempty"`
+}
+
+// ProducerExecuteResponse represents the response from executing a producer
+type ProducerExecuteResponse struct {
+	Production *ProductionResponse `json:"production"`
+	Content    string              `json:"content,omitempty"`
+}
+
+// ProducerPreferences represents user preferences for producers
+type ProducerPreferences struct {
+	Pinned   *PinnedProducers         `json:"pinned,omitempty"`
+	Order    *OrderedProducers        `json:"order,omitempty"`
+	Recent   []string                 `json:"recent,omitempty"`
+	Settings *ProducerSettingsPrefs   `json:"settings,omitempty"`
+}
+
+// PinnedProducers represents pinned producer agents at different levels
+type PinnedProducers struct {
+	Global     []string            `json:"global,omitempty"`      // Globally pinned agents
+	BySpace    map[string][]string `json:"by_space,omitempty"`    // Pinned by space ID
+	ByNotebook map[string][]string `json:"by_notebook,omitempty"` // Pinned by notebook ID
+}
+
+// OrderedProducers represents custom ordering of producer agents at different levels
+type OrderedProducers struct {
+	Global     []string            `json:"global,omitempty"`      // Global custom order of agent IDs
+	BySpace    map[string][]string `json:"by_space,omitempty"`    // Custom order by space ID
+	ByNotebook map[string][]string `json:"by_notebook,omitempty"` // Custom order by notebook ID
+}
+
+// ProducerSettingsPrefs represents producer settings preferences
+type ProducerSettingsPrefs struct {
+	DefaultFormat ProductionFormat `json:"default_format,omitempty"`
+	DefaultType   ProductionType   `json:"default_type,omitempty"`
+}
+
+// UpdateProducerPreferencesRequest represents a request to update producer preferences
+type UpdateProducerPreferencesRequest struct {
+	// Pin/unpin actions
+	PinGlobal      *string `json:"pin_global,omitempty" validate:"omitempty,uuid"`      // Agent ID to pin globally
+	UnpinGlobal    *string `json:"unpin_global,omitempty" validate:"omitempty,uuid"`    // Agent ID to unpin globally
+	PinToSpace     *string `json:"pin_to_space,omitempty" validate:"omitempty,uuid"`    // Agent ID to pin to current space
+	UnpinFromSpace *string `json:"unpin_from_space,omitempty" validate:"omitempty,uuid"` // Agent ID to unpin from current space
+	PinToNotebook  *string `json:"pin_to_notebook,omitempty" validate:"omitempty,uuid"` // Agent ID to pin to specified notebook
+	UnpinFromNotebook *string `json:"unpin_from_notebook,omitempty" validate:"omitempty,uuid"` // Agent ID to unpin
+
+	// Order actions (for drag-and-drop reordering)
+	SetOrderGlobal     []string `json:"set_order_global,omitempty"`      // Set global custom order of agent IDs
+	SetOrderForSpace   []string `json:"set_order_for_space,omitempty"`   // Set custom order for a specific space
+	SetOrderForNotebook []string `json:"set_order_for_notebook,omitempty"` // Set custom order for a specific notebook
+
+	// Context for pin/order operations
+	SpaceID    string `json:"space_id,omitempty"`
+	NotebookID string `json:"notebook_id,omitempty"`
+
+	// Settings updates
+	DefaultFormat *ProductionFormat `json:"default_format,omitempty" validate:"omitempty,oneof=markdown html json text"`
+	DefaultType   *ProductionType   `json:"default_type,omitempty" validate:"omitempty,oneof=summary qa outline insight custom"`
+}
+
+// NewProduction creates a new production with default values
+func NewProduction(req ProducerExecuteRequest, agentID, agentBuilderID, notebookID, userID string, spaceCtx *SpaceContext) *Production {
+	now := time.Now()
+	return &Production{
+		ID:              uuid.New().String(),
+		Title:           req.Title,
+		Type:            req.Type,
+		Format:          req.Format,
+		Status:          ProductionStatusProcessing,
+		AgentID:         agentID,
+		AgentBuilderID:  agentBuilderID,
+		NotebookID:      notebookID,
+		UserID:          userID,
+		SpaceType:       spaceCtx.SpaceType,
+		SpaceID:         spaceCtx.SpaceID,
+		TenantID:        spaceCtx.TenantID,
+		SourceDocuments: req.SourceDocuments,
+		SearchText:      buildProductionSearchText(req.Title, string(req.Type)),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+}
+
+// ToResponse converts a Production to ProductionResponse
+func (p *Production) ToResponse() *ProductionResponse {
+	return &ProductionResponse{
+		ID:              p.ID,
+		Title:           p.Title,
+		Type:            p.Type,
+		Format:          p.Format,
+		Status:          p.Status,
+		AgentID:         p.AgentID,
+		AgentBuilderID:  p.AgentBuilderID,
+		NotebookID:      p.NotebookID,
+		UserID:          p.UserID,
+		SpaceType:       p.SpaceType,
+		SpaceID:         p.SpaceID,
+		SizeBytes:       p.SizeBytes,
+		ExecutionID:     p.ExecutionID,
+		TokensUsed:      p.TokensUsed,
+		CostUSD:         p.CostUSD,
+		ResponseTimeMs:  p.ResponseTimeMs,
+		ErrorMessage:    p.ErrorMessage,
+		SourceDocuments: p.SourceDocuments,
+		CreatedAt:       p.CreatedAt,
+		UpdatedAt:       p.UpdatedAt,
+	}
+}
+
+// Update updates production fields from an update request
+func (p *Production) Update(req ProductionUpdateRequest) {
+	if req.Title != nil {
+		p.Title = *req.Title
+	}
+	if req.Status != nil {
+		p.Status = *req.Status
+	}
+	p.SearchText = buildProductionSearchText(p.Title, string(p.Type))
+	p.UpdatedAt = time.Now()
+}
+
+// MarkCompleted marks the production as completed with execution details
+func (p *Production) MarkCompleted(storageKey, storageBucket string, sizeBytes int64, executionID string, tokensUsed int, costUSD float64, responseTimeMs int) {
+	p.Status = ProductionStatusCompleted
+	p.StorageKey = storageKey
+	p.StorageBucket = storageBucket
+	p.SizeBytes = sizeBytes
+	p.ExecutionID = executionID
+	p.TokensUsed = tokensUsed
+	p.CostUSD = costUSD
+	p.ResponseTimeMs = responseTimeMs
+	p.UpdatedAt = time.Now()
+}
+
+// MarkFailed marks the production as failed with an error message
+func (p *Production) MarkFailed(errorMessage string) {
+	p.Status = ProductionStatusFailed
+	p.ErrorMessage = errorMessage
+	p.UpdatedAt = time.Now()
+}
+
+// IsCompleted returns true if the production is completed
+func (p *Production) IsCompleted() bool {
+	return p.Status == ProductionStatusCompleted
+}
+
+// IsFailed returns true if the production has failed
+func (p *Production) IsFailed() bool {
+	return p.Status == ProductionStatusFailed
+}
+
+// IsProcessing returns true if the production is still processing
+func (p *Production) IsProcessing() bool {
+	return p.Status == ProductionStatusProcessing
+}
+
+// CanBeAccessedBy checks if a user can access this production
+func (p *Production) CanBeAccessedBy(userID string) bool {
+	return p.UserID == userID
+}
+
+// GetStoragePath returns the full S3 path for this production
+func (p *Production) GetStoragePath() string {
+	if p.StorageKey == "" {
+		return ""
+	}
+	return p.StorageKey
+}
+
+// buildProductionSearchText creates a searchable text field from title and type
+func buildProductionSearchText(title, prodType string) string {
+	return title + " " + prodType
+}
+
+// BulkDeleteProductionsRequest represents a request to delete multiple productions
+type BulkDeleteProductionsRequest struct {
+	ProductionIDs []string `json:"production_ids" validate:"required,min=1,max=100,dive,uuid"`
+}
+
+// BulkDeleteProductionsResponse represents the response from a bulk delete operation
+type BulkDeleteProductionsResponse struct {
+	Deleted []string             `json:"deleted"`
+	Failed  []BulkDeleteFailure  `json:"failed,omitempty"`
+}
+
+// BulkDeleteFailure represents a failed deletion in a bulk operation
+type BulkDeleteFailure struct {
+	ProductionID string `json:"production_id"`
+	Error        string `json:"error"`
+}
+
+// BuildProductionStorageKey constructs the S3 storage key for a production
+// Pattern: spaces/{space_type}/notebooks/{notebook_id}/productions/{production_id}/{filename}
+func BuildProductionStorageKey(spaceType, notebookID, productionID, filename string) string {
+	return "spaces/" + spaceType + "/notebooks/" + notebookID + "/productions/" + productionID + "/" + filename
+}

--- a/internal/services/agent.go
+++ b/internal/services/agent.go
@@ -1399,13 +1399,328 @@ func (s *AgentService) canUserAccessAgent(agent *models.Agent, userID string, us
 	if agent.OwnerID == userID {
 		return true
 	}
-	
+
 	// 2. Agent is public
 	if agent.IsPublic {
 		return true
 	}
-	
+
 	// For now, allow access if the user is in the same space
 	// TODO: Implement proper team-based access control
 	return true
+}
+
+// GetInternalAgents fetches internal (system) agents from agent-builder
+func (s *AgentService) GetInternalAgents(ctx context.Context, authToken string) ([]*models.AgentResponse, error) {
+	endpoint := "/agents/internal"
+	requestURL := s.agentBuilderURL + endpoint
+
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", requestURL, nil)
+	if err != nil {
+		return nil, errors.ExternalService("Failed to create agent-builder request", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+authToken)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		s.logger.Error("Failed to fetch internal agents from agent-builder", zap.Error(err))
+		return nil, errors.ExternalService("Agent-builder service unavailable", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.ExternalService("Failed to read agent-builder response", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		s.logger.Error("Agent-builder returned non-OK status for internal agents",
+			zap.Int("status", resp.StatusCode),
+			zap.String("body", string(bodyBytes)),
+		)
+		return nil, errors.ExternalService(fmt.Sprintf("Agent-builder error: %s", string(bodyBytes)), nil)
+	}
+
+	// Parse response - agent-builder returns {"agents": [...], "count": N}
+	var responseWrapper struct {
+		Agents []map[string]interface{} `json:"agents"`
+		Count  int                      `json:"count"`
+	}
+	if err := json.Unmarshal(bodyBytes, &responseWrapper); err != nil {
+		s.logger.Error("Failed to parse agent-builder response",
+			zap.Error(err),
+			zap.String("body", string(bodyBytes)),
+		)
+		return nil, errors.ExternalService("Failed to parse agent-builder response", err)
+	}
+
+	agents := make([]*models.AgentResponse, 0, len(responseWrapper.Agents))
+	for _, agentMap := range responseWrapper.Agents {
+		agent := s.mapToAgentResponse(agentMap)
+		agents = append(agents, agent)
+	}
+
+	s.logger.Debug("Fetched internal agents from agent-builder",
+		zap.Int("count", len(agents)),
+	)
+
+	return agents, nil
+}
+
+// GetInternalProducerAgents fetches internal producer agents from agent-builder
+func (s *AgentService) GetInternalProducerAgents(ctx context.Context, authToken string) ([]*models.AgentResponse, error) {
+	allInternal, err := s.GetInternalAgents(ctx, authToken)
+	if err != nil {
+		return nil, err
+	}
+
+	producers := make([]*models.AgentResponse, 0)
+	for _, agent := range allInternal {
+		if agent.Type == models.AgentTypeProducer {
+			producers = append(producers, agent)
+		}
+	}
+
+	s.logger.Debug("Filtered internal producer agents",
+		zap.Int("total_internal", len(allInternal)),
+		zap.Int("producers", len(producers)),
+	)
+
+	return producers, nil
+}
+
+// GetInternalAgentByID fetches a specific internal agent from agent-builder by ID
+func (s *AgentService) GetInternalAgentByID(ctx context.Context, agentID string, authToken string) (*models.AgentResponse, error) {
+	endpoint := fmt.Sprintf("/agents/internal/%s", agentID)
+	requestURL := s.agentBuilderURL + endpoint
+
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", requestURL, nil)
+	if err != nil {
+		return nil, errors.ExternalService("Failed to create agent-builder request", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+authToken)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		s.logger.Error("Failed to fetch internal agent from agent-builder", zap.Error(err), zap.String("agent_id", agentID))
+		return nil, errors.ExternalService("Agent-builder service unavailable", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil // Agent not found - not an error, just not an internal agent
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.ExternalService("Failed to read agent-builder response", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		s.logger.Error("Agent-builder returned non-OK status for internal agent",
+			zap.Int("status", resp.StatusCode),
+			zap.String("body", string(bodyBytes)),
+			zap.String("agent_id", agentID),
+		)
+		return nil, errors.ExternalService(fmt.Sprintf("Agent-builder error: %s", string(bodyBytes)), nil)
+	}
+
+	var agentMap map[string]interface{}
+	if err := json.Unmarshal(bodyBytes, &agentMap); err != nil {
+		return nil, errors.ExternalService("Failed to parse agent-builder response", err)
+	}
+
+	agent := s.mapToAgentResponse(agentMap)
+	return agent, nil
+}
+
+// ConversationMessage represents a message in conversation history
+type ConversationMessage struct {
+	Role      string `json:"role"`
+	Content   string `json:"content"`
+	Timestamp string `json:"timestamp,omitempty"`
+}
+
+// InternalAgentExecuteRequest represents a request to execute an internal agent
+type InternalAgentExecuteRequest struct {
+	Input             string                 `json:"input"`
+	NotebookIDs       []string               `json:"notebook_ids,omitempty"`
+	SelectedDocuments []string               `json:"selected_documents,omitempty"`
+	TenantID          string                 `json:"tenant_id,omitempty"`
+	SessionID         string                 `json:"session_id,omitempty"`
+	History           []ConversationMessage  `json:"history,omitempty"`
+	Context           map[string]interface{} `json:"context,omitempty"`
+}
+
+// InternalAgentExecuteResponse represents the response from executing an internal agent
+type InternalAgentExecuteResponse struct {
+	ExecutionID     string                 `json:"execution_id"`
+	Output          string                 `json:"output"`
+	TokensUsed      int                    `json:"tokens_used"`
+	CostUSD         float64                `json:"cost_usd"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty"`
+	ContextMetadata map[string]interface{} `json:"context_metadata,omitempty"`
+	ConversationID  string                 `json:"conversation_id,omitempty"`
+}
+
+// ExecuteInternalAgent executes an internal agent via agent-builder with document context
+func (s *AgentService) ExecuteInternalAgent(ctx context.Context, agentID string, req InternalAgentExecuteRequest, authToken string) (*InternalAgentExecuteResponse, error) {
+	endpoint := fmt.Sprintf("/agents/internal/%s/execute", agentID)
+	requestURL := s.agentBuilderURL + endpoint
+
+	// Build request body
+	reqBody := map[string]interface{}{
+		"input": req.Input,
+	}
+
+	if len(req.NotebookIDs) > 0 {
+		reqBody["notebook_ids"] = req.NotebookIDs
+	}
+	if len(req.SelectedDocuments) > 0 {
+		reqBody["selected_documents"] = req.SelectedDocuments
+	}
+	if req.TenantID != "" {
+		reqBody["tenant_id"] = req.TenantID
+	}
+	if req.SessionID != "" {
+		reqBody["session_id"] = req.SessionID
+	}
+	if len(req.History) > 0 {
+		reqBody["history"] = req.History
+	}
+	if req.Context != nil && len(req.Context) > 0 {
+		reqBody["context"] = req.Context
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, errors.InternalWithCause("Failed to marshal execute request", err)
+	}
+
+	s.logger.Info("Executing internal agent via agent-builder",
+		zap.String("agent_id", agentID),
+		zap.String("endpoint", endpoint),
+		zap.Int("notebook_count", len(req.NotebookIDs)),
+		zap.Int("document_count", len(req.SelectedDocuments)),
+		zap.String("tenant_id", req.TenantID),
+	)
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", requestURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, errors.ExternalService("Failed to create agent-builder request", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+authToken)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	// Use longer timeout for execution requests
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		s.logger.Error("Failed to execute internal agent", zap.Error(err), zap.String("agent_id", agentID))
+		return nil, errors.ExternalService("Agent-builder service unavailable", err)
+	}
+	defer resp.Body.Close()
+
+	respBodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.ExternalService("Failed to read agent-builder response", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		s.logger.Error("Agent-builder execution failed",
+			zap.Int("status", resp.StatusCode),
+			zap.String("body", string(respBodyBytes)),
+			zap.String("agent_id", agentID),
+		)
+		return nil, errors.ExternalService(fmt.Sprintf("Agent-builder execution error: %s", string(respBodyBytes)), nil)
+	}
+
+	var response InternalAgentExecuteResponse
+	if err := json.Unmarshal(respBodyBytes, &response); err != nil {
+		return nil, errors.ExternalService("Failed to parse agent-builder response", err)
+	}
+
+	s.logger.Info("Internal agent execution completed",
+		zap.String("agent_id", agentID),
+		zap.String("execution_id", response.ExecutionID),
+		zap.Int("output_length", len(response.Output)),
+		zap.Int("tokens_used", response.TokensUsed),
+	)
+
+	return &response, nil
+}
+
+// mapToAgentResponse converts a map from agent-builder to AgentResponse
+func (s *AgentService) mapToAgentResponse(agentMap map[string]interface{}) *models.AgentResponse {
+	agent := &models.AgentResponse{}
+
+	if id, ok := agentMap["id"].(string); ok {
+		agent.ID = id
+	}
+	if name, ok := agentMap["name"].(string); ok {
+		agent.Name = name
+	}
+	if description, ok := agentMap["description"].(string); ok {
+		agent.Description = description
+	}
+	if systemPrompt, ok := agentMap["system_prompt"].(string); ok {
+		agent.SystemPrompt = systemPrompt
+	}
+	if status, ok := agentMap["status"].(string); ok {
+		agent.Status = models.AgentStatus(status)
+	}
+	if agentType, ok := agentMap["type"].(string); ok {
+		agent.Type = models.AgentType(agentType)
+	}
+	if spaceType, ok := agentMap["space_type"].(string); ok {
+		agent.SpaceType = models.SpaceType(spaceType)
+	}
+	if ownerID, ok := agentMap["owner_id"].(string); ok {
+		agent.OwnerID = ownerID
+	}
+	if spaceID, ok := agentMap["space_id"].(string); ok {
+		agent.SpaceID = spaceID
+	}
+	if isPublic, ok := agentMap["is_public"].(bool); ok {
+		agent.IsPublic = isPublic
+	}
+	if isTemplate, ok := agentMap["is_template"].(bool); ok {
+		agent.IsTemplate = isTemplate
+	}
+
+	// Parse LLM config - keep as map[string]interface{} as that's what AgentResponse expects
+	if llmConfig, ok := agentMap["llm_config"].(map[string]interface{}); ok {
+		agent.LLMConfig = llmConfig
+	}
+
+	// Parse tags
+	if tags, ok := agentMap["tags"].([]interface{}); ok {
+		agent.Tags = make([]string, 0, len(tags))
+		for _, tag := range tags {
+			if tagStr, ok := tag.(string); ok {
+				agent.Tags = append(agent.Tags, tagStr)
+			}
+		}
+	}
+
+	// Parse timestamps
+	if createdAt, ok := agentMap["created_at"].(string); ok {
+		if t, err := time.Parse(time.RFC3339, createdAt); err == nil {
+			agent.CreatedAt = t
+		}
+	}
+	if updatedAt, ok := agentMap["updated_at"].(string); ok {
+		if t, err := time.Parse(time.RFC3339, updatedAt); err == nil {
+			agent.UpdatedAt = t
+		}
+	}
+
+	return agent
 }

--- a/internal/services/agent_execution_direct.go
+++ b/internal/services/agent_execution_direct.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -8,10 +9,11 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
-	"github.com/Tributary-ai-services/aether-be/pkg/errors"
 	"github.com/Tributary-ai-services/aether-be/internal/models"
+	"github.com/Tributary-ai-services/aether-be/pkg/errors"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
@@ -125,6 +127,7 @@ func (s *AgentService) buildLLMRequest(agent *models.Agent, req models.AgentExec
 		"temperature": 0.7,
 		"max_tokens":  500,
 		"provider":    "openai",
+		"stream":      true, // Enable streaming to avoid timeouts on large outputs
 	}
 }
 
@@ -135,9 +138,56 @@ type LLMResponse struct {
 	Provider   string
 }
 
+// ExecuteLLMRequest executes an LLM request with the provided messages and config
+// This is a public method that can be called from other services
+func (s *AgentService) ExecuteLLMRequest(ctx context.Context, messages []map[string]string, llmConfig map[string]interface{}, authToken string) (string, error) {
+	// Extract config values with defaults
+	provider := "openai"
+	model := "gpt-4o-mini"
+	temperature := 0.7
+	maxTokens := 2048
+
+	if p, ok := llmConfig["provider"].(string); ok {
+		provider = p
+	}
+	if m, ok := llmConfig["model"].(string); ok {
+		model = m
+	}
+	if t, ok := llmConfig["temperature"].(float64); ok {
+		temperature = t
+	}
+	if mt, ok := llmConfig["max_tokens"].(int); ok {
+		maxTokens = mt
+	}
+
+	// Build the request body with streaming enabled to avoid timeouts
+	request := map[string]interface{}{
+		"messages":    messages,
+		"model":       model,
+		"provider":    provider,
+		"temperature": temperature,
+		"max_tokens":  maxTokens,
+		"stream":      true,
+	}
+
+	response, err := s.callRouterService(ctx, request, authToken)
+	if err != nil {
+		s.logger.Error("LLM request failed", zap.Error(err))
+		return "", err
+	}
+
+	return response.Content, nil
+}
+
 func (s *AgentService) callRouterService(ctx context.Context, request map[string]interface{}, authToken string) (*LLMResponse, error) {
 	// Use the router service URL from environment or default
 	routerURL := s.getRouterServiceURL()
+
+	// Check if streaming is enabled
+	isStreaming := false
+	if stream, ok := request["stream"].(bool); ok && stream {
+		isStreaming = true
+	}
 
 	jsonData, err := json.Marshal(request)
 	if err != nil {
@@ -155,7 +205,9 @@ func (s *AgentService) callRouterService(ctx context.Context, request map[string
 		req.Header.Set("Authorization", "Bearer "+authToken)
 	}
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	// Use a longer timeout for LLM requests
+	// With streaming, this is mostly for initial connection; chunks keep the connection alive
+	client := &http.Client{Timeout: 300 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -167,23 +219,140 @@ func (s *AgentService) callRouterService(ctx context.Context, request map[string
 		return nil, fmt.Errorf("router service error: %s", string(body))
 	}
 
+	// Handle streaming vs non-streaming responses
+	if isStreaming {
+		return s.handleStreamingResponse(resp, request)
+	}
+
+	return s.handleNonStreamingResponse(resp, request)
+}
+
+// handleStreamingResponse parses SSE streaming response and accumulates content
+func (s *AgentService) handleStreamingResponse(resp *http.Response, request map[string]interface{}) (*LLMResponse, error) {
+	var contentBuilder strings.Builder
+	var totalTokens int
+	var model, provider string
+
+	// Extract model and provider from request for response
+	if m, ok := request["model"].(string); ok {
+		model = m
+	}
+	if p, ok := request["provider"].(string); ok {
+		provider = p
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	// Increase buffer size for potentially large chunks
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, ":") {
+			continue
+		}
+
+		// SSE format: "data: {...}" or "data: [DONE]"
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		data := strings.TrimPrefix(line, "data: ")
+
+		// Check for stream end signal
+		if data == "[DONE]" {
+			break
+		}
+
+		// Parse the JSON chunk
+		var chunk map[string]interface{}
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			s.logger.Warn("Failed to parse streaming chunk", zap.String("data", data), zap.Error(err))
+			continue
+		}
+
+		// Extract content from delta
+		if choices, ok := chunk["choices"].([]interface{}); ok && len(choices) > 0 {
+			if choice, ok := choices[0].(map[string]interface{}); ok {
+				// Streaming uses "delta" instead of "message"
+				if delta, ok := choice["delta"].(map[string]interface{}); ok {
+					if content, ok := delta["content"].(string); ok {
+						contentBuilder.WriteString(content)
+					}
+				}
+			}
+		}
+
+		// Extract usage from final chunk (if provided)
+		if usage, ok := chunk["usage"].(map[string]interface{}); ok {
+			if tokens, ok := usage["total_tokens"].(float64); ok {
+				totalTokens = int(tokens)
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading streaming response: %w", err)
+	}
+
+	content := contentBuilder.String()
+	if content == "" {
+		return nil, fmt.Errorf("no content received from streaming response")
+	}
+
+	// Estimate tokens if not provided (rough estimate: ~4 chars per token)
+	if totalTokens == 0 {
+		totalTokens = len(content) / 4
+	}
+
+	s.logger.Info("Streaming response completed",
+		zap.Int("content_length", len(content)),
+		zap.Int("estimated_tokens", totalTokens))
+
+	return &LLMResponse{
+		Content:    content,
+		TokensUsed: totalTokens,
+		Model:      model,
+		Provider:   provider,
+	}, nil
+}
+
+// handleNonStreamingResponse parses standard JSON response
+func (s *AgentService) handleNonStreamingResponse(resp *http.Response, request map[string]interface{}) (*LLMResponse, error) {
 	var result map[string]interface{}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, err
 	}
 
 	// Extract response from OpenAI-compatible format
-	choices := result["choices"].([]interface{})
-	if len(choices) == 0 {
+	choices, ok := result["choices"].([]interface{})
+	if !ok || len(choices) == 0 {
 		return nil, fmt.Errorf("no response from LLM")
 	}
 
-	choice := choices[0].(map[string]interface{})
-	message := choice["message"].(map[string]interface{})
-	content := message["content"].(string)
+	choice, ok := choices[0].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid choice format in LLM response")
+	}
 
-	usage := result["usage"].(map[string]interface{})
-	totalTokens := int(usage["total_tokens"].(float64))
+	message, ok := choice["message"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid message format in LLM response")
+	}
+
+	content, ok := message["content"].(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid content format in LLM response")
+	}
+
+	var totalTokens int
+	if usage, ok := result["usage"].(map[string]interface{}); ok {
+		if tokens, ok := usage["total_tokens"].(float64); ok {
+			totalTokens = int(tokens)
+		}
+	}
 
 	return &LLMResponse{
 		Content:    content,
@@ -265,11 +434,14 @@ func truncate(s string, maxLen int) string {
 
 // getRouterServiceURL returns the router service URL from environment or default
 func (s *AgentService) getRouterServiceURL() string {
-	// Try to get from environment variables
+	// Try to get from environment variables - check both naming conventions
+	if url := os.Getenv("ROUTER_SERVICE_BASE_URL"); url != "" {
+		return url + "/v1/chat/completions"
+	}
 	if url := os.Getenv("ROUTER_SERVICE_URL"); url != "" {
 		return url + "/v1/chat/completions"
 	}
-	
+
 	// Default to localhost for development
 	return "http://localhost:8086/v1/chat/completions"
 }

--- a/internal/services/audimodal.go
+++ b/internal/services/audimodal.go
@@ -358,6 +358,13 @@ func (s *AudiModalService) getAudiModalTenantUUID(ctx context.Context, aetherTen
 	return mapping.TenantUUID, nil
 }
 
+// GetAudiModalTenantUUID is the public version of getAudiModalTenantUUID.
+// It resolves an Aether tenant ID (e.g., "tenant_1766596584" or "tenant_<UUID>") to an AudiModal UUID.
+// If the tenant doesn't exist in AudiModal, it will be created automatically.
+func (s *AudiModalService) GetAudiModalTenantUUID(ctx context.Context, aetherTenantID string) (string, error) {
+	return s.getAudiModalTenantUUID(ctx, aetherTenantID)
+}
+
 // getAudiModalMapping resolves an Aether tenant ID to an AudiModal tenant and datasource mapping.
 // If the tenant ID is already a UUID (after stripping "tenant_" prefix), it uses the default datasource.
 // If it's a numeric ID, it creates a new AudiModal tenant and datasource.

--- a/internal/services/crawl4ai.go
+++ b/internal/services/crawl4ai.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Tributary-ai-services/aether-be/internal/config"
 	"github.com/Tributary-ai-services/aether-be/internal/logger"
+	"github.com/Tributary-ai-services/aether-be/internal/validation"
 )
 
 // Crawl4AIService provides web scraping capabilities via Crawl4AI
@@ -266,6 +267,24 @@ var aiUserAgents = []string{
 	"diffbot",
 	"facebookbot",
 	"google-extended",
+}
+
+// DefaultExcludedTags are HTML tags to exclude at crawl time to prevent XSS and reduce noise
+// These are stripped by Crawl4AI before markdown/content extraction
+var DefaultExcludedTags = []string{
+	"script",
+	"style",
+	"noscript",
+	"iframe",
+	"object",
+	"embed",
+	"applet",
+	"form",
+	"input",
+	"button",
+	"select",
+	"textarea",
+	"svg", // SVG can contain embedded scripts
 }
 
 // ============================================================================
@@ -747,6 +766,16 @@ func (s *Crawl4AIService) ScrapeURL(ctx context.Context, targetURL string, scrap
 		return result, nil
 	}
 
+	// Apply content sanitization if enabled (defense-in-depth after excluded_tags)
+	// Check for option override first, then fall back to config
+	sanitize := s.config.SanitizeContent
+	if optSanitize, ok := options["sanitize_content"].(bool); ok {
+		sanitize = optSanitize
+	}
+	if sanitize {
+		s.SanitizeScrapeResult(result)
+	}
+
 	result.Success = true
 	return result, nil
 }
@@ -756,6 +785,9 @@ func (s *Crawl4AIService) scrapeWithCrawl4AI(ctx context.Context, targetURL stri
 	crawlReq := Crawl4AIRequest{
 		URLs:               []string{targetURL},
 		WordCountThreshold: 10,
+		ExcludedTags:       DefaultExcludedTags, // Always exclude dangerous tags
+		ExcludeExternalLinks: false,
+		ExcludeExternalImages: false,
 	}
 
 	// Apply options
@@ -764,6 +796,14 @@ func (s *Crawl4AIService) scrapeWithCrawl4AI(ctx context.Context, targetURL stri
 	}
 	if screenshot, ok := options["screenshot"].(bool); ok {
 		crawlReq.Screenshot = screenshot
+	}
+	// Allow overriding excluded tags if explicitly provided
+	if excludedTags, ok := options["excluded_tags"].([]string); ok {
+		crawlReq.ExcludedTags = excludedTags
+	}
+	// Allow adding additional excluded tags
+	if additionalTags, ok := options["additional_excluded_tags"].([]string); ok {
+		crawlReq.ExcludedTags = append(crawlReq.ExcludedTags, additionalTags...)
 	}
 
 	reqBody, err := json.Marshal(crawlReq)
@@ -928,6 +968,131 @@ func (s *Crawl4AIService) scrapeArchiveOrg(ctx context.Context, targetURL, archi
 
 	// Fetch from archive.org using Crawl4AI for JS rendering
 	return s.scrapeWithCrawl4AI(ctx, archiveURL, nil, result)
+}
+
+// ============================================================================
+// Content Sanitization
+// ============================================================================
+
+// SanitizeScrapeResult sanitizes all content in a scrape result to prevent XSS
+// This provides defense-in-depth after excluded_tags filtering at crawl time
+func (s *Crawl4AIService) SanitizeScrapeResult(result *ScrapeResult) {
+	if result == nil {
+		return
+	}
+
+	// Get sanitization options
+	htmlOptions := validation.DefaultWebContentSanitizationOptions()
+	mdOptions := validation.DefaultWebContentSanitizationOptions()
+	mdOptions.PreserveMarkdown = true
+
+	// Sanitize main content
+	if result.Content != "" {
+		if result.ContentType == "text/markdown" {
+			result.Content = validation.SanitizeMarkdownContent(result.Content, mdOptions)
+		} else {
+			result.Content = validation.SanitizeWebContent(result.Content, htmlOptions)
+		}
+	}
+
+	// Sanitize HTML
+	if result.HTML != "" {
+		result.HTML = validation.SanitizeWebContent(result.HTML, htmlOptions)
+	}
+
+	// Sanitize Markdown
+	if result.Markdown != "" {
+		result.Markdown = validation.SanitizeMarkdownContent(result.Markdown, mdOptions)
+	}
+
+	// Sanitize title
+	if result.Title != "" {
+		result.Title = validation.SanitizeTitle(result.Title)
+	}
+
+	// Sanitize metadata
+	if result.Metadata != nil {
+		for key, value := range result.Metadata {
+			result.Metadata[key] = validation.SanitizeDescription(value)
+		}
+	}
+
+	// Sanitize media URLs
+	if result.Media != nil {
+		s.sanitizeMedia(result.Media)
+	}
+
+	// Sanitize link URLs
+	if result.Links != nil {
+		s.sanitizeLinks(result.Links)
+	}
+
+	s.log.Debug("Sanitized scrape result",
+		zap.String("url", result.URL),
+		zap.Int("content_length", len(result.Content)),
+		zap.Int("html_length", len(result.HTML)),
+		zap.Int("markdown_length", len(result.Markdown)))
+}
+
+// sanitizeMedia sanitizes all media URLs in a Crawl4AIMedia struct
+func (s *Crawl4AIService) sanitizeMedia(media *Crawl4AIMedia) {
+	if media == nil {
+		return
+	}
+
+	// Sanitize image URLs
+	for i := range media.Images {
+		media.Images[i].Src = validation.SanitizeMediaURL(media.Images[i].Src)
+		media.Images[i].Alt = validation.SanitizeTitle(media.Images[i].Alt)
+	}
+
+	// Sanitize video URLs
+	for i := range media.Videos {
+		media.Videos[i].Src = validation.SanitizeMediaURL(media.Videos[i].Src)
+		media.Videos[i].Poster = validation.SanitizeMediaURL(media.Videos[i].Poster)
+	}
+
+	// Sanitize audio URLs
+	for i := range media.Audios {
+		media.Audios[i].Src = validation.SanitizeMediaURL(media.Audios[i].Src)
+	}
+}
+
+// sanitizeLinks sanitizes all URLs in a Crawl4AILinks struct
+func (s *Crawl4AIService) sanitizeLinks(links *Crawl4AILinks) {
+	if links == nil {
+		return
+	}
+
+	// Sanitize internal links
+	sanitizedInternal := make([]Crawl4AILink, 0, len(links.Internal))
+	for _, link := range links.Internal {
+		sanitizedHref := validation.SanitizeURL(link.Href)
+		if sanitizedHref != "" { // Only keep links with valid URLs
+			sanitizedInternal = append(sanitizedInternal, Crawl4AILink{
+				Href:       sanitizedHref,
+				Text:       validation.SanitizeTitle(link.Text),
+				Title:      validation.SanitizeTitle(link.Title),
+				BaseDomain: link.BaseDomain,
+			})
+		}
+	}
+	links.Internal = sanitizedInternal
+
+	// Sanitize external links
+	sanitizedExternal := make([]Crawl4AILink, 0, len(links.External))
+	for _, link := range links.External {
+		sanitizedHref := validation.SanitizeURL(link.Href)
+		if sanitizedHref != "" { // Only keep links with valid URLs
+			sanitizedExternal = append(sanitizedExternal, Crawl4AILink{
+				Href:       sanitizedHref,
+				Text:       validation.SanitizeTitle(link.Text),
+				Title:      validation.SanitizeTitle(link.Title),
+				BaseDomain: link.BaseDomain,
+			})
+		}
+	}
+	links.External = sanitizedExternal
 }
 
 // ============================================================================

--- a/internal/services/notebook.go
+++ b/internal/services/notebook.go
@@ -968,12 +968,236 @@ func (s *NotebookService) deserializeComplianceSettings(jsonString string) (map[
 	if jsonString == "" || jsonString == "{}" {
 		return nil, nil
 	}
-	
+
 	var settings map[string]interface{}
 	if err := json.Unmarshal([]byte(jsonString), &settings); err != nil {
 		s.logger.Error("Failed to deserialize compliance settings", zap.String("json", jsonString), zap.Error(err))
 		return nil, errors.InternalWithCause("Failed to deserialize compliance settings", err)
 	}
-	
+
 	return settings, nil
+}
+
+// ============================================================================
+// Internal API methods for service-to-service communication
+// These methods support agent-builder and other services for document retrieval
+// ============================================================================
+
+// NotebookHierarchy represents a notebook with its sub-notebooks for hierarchy queries
+type NotebookHierarchy struct {
+	ID           string              `json:"id"`
+	Name         string              `json:"name"`
+	ParentID     string              `json:"parent_id,omitempty"`
+	Documents    []NotebookDocument  `json:"documents,omitempty"`
+	SubNotebooks []NotebookHierarchy `json:"sub_notebooks,omitempty"`
+}
+
+// NotebookDocument represents a document in a notebook for internal queries
+type NotebookDocument struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	NotebookID   string `json:"notebook_id"`
+	NotebookName string `json:"notebook_name,omitempty"`
+	FileID       string `json:"file_id,omitempty"`
+	ContentType  string `json:"content_type,omitempty"`
+	SizeBytes    int64  `json:"size_bytes,omitempty"`
+	ChunkCount   int    `json:"chunk_count,omitempty"`
+	CreatedAt    string `json:"created_at,omitempty"`
+}
+
+// GetNotebookHierarchy retrieves notebook hierarchy including sub-notebooks recursively
+func (s *NotebookService) GetNotebookHierarchy(ctx context.Context, notebookID, tenantID string) (*NotebookHierarchy, error) {
+	// First, get the main notebook
+	query := `
+		MATCH (n:Notebook {id: $notebook_id, tenant_id: $tenant_id})
+		RETURN n.id as id, n.name as name, n.parent_id as parent_id
+	`
+
+	result, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, map[string]interface{}{
+		"notebook_id": notebookID,
+		"tenant_id":   tenantID,
+	})
+	if err != nil {
+		s.logger.Error("Failed to get notebook", zap.Error(err))
+		return nil, errors.InternalWithCause("Failed to get notebook hierarchy", err)
+	}
+
+	records := result.Records
+	if len(records) == 0 {
+		return nil, errors.NotFound("Notebook not found")
+	}
+
+	record := records[0]
+	hierarchy := &NotebookHierarchy{
+		ID:       s.getString(record.Values[0]),
+		Name:     s.getString(record.Values[1]),
+		ParentID: s.getString(record.Values[2]),
+	}
+
+	// Get documents for this notebook
+	documents, err := s.GetNotebookDocuments(ctx, notebookID, tenantID)
+	if err == nil {
+		hierarchy.Documents = documents
+	}
+
+	// Get sub-notebooks recursively
+	subNotebooks, err := s.getSubNotebooksRecursive(ctx, notebookID, tenantID)
+	if err == nil {
+		hierarchy.SubNotebooks = subNotebooks
+	}
+
+	return hierarchy, nil
+}
+
+// getSubNotebooksRecursive recursively fetches sub-notebooks
+func (s *NotebookService) getSubNotebooksRecursive(ctx context.Context, parentID, tenantID string) ([]NotebookHierarchy, error) {
+	query := `
+		MATCH (parent:Notebook {id: $parent_id, tenant_id: $tenant_id})-[:CONTAINS]->(child:Notebook {tenant_id: $tenant_id})
+		RETURN child.id as id, child.name as name, child.parent_id as parent_id
+	`
+
+	result, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, map[string]interface{}{
+		"parent_id": parentID,
+		"tenant_id": tenantID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var subNotebooks []NotebookHierarchy
+	for _, record := range result.Records {
+		subNotebook := NotebookHierarchy{
+			ID:       s.getString(record.Values[0]),
+			Name:     s.getString(record.Values[1]),
+			ParentID: s.getString(record.Values[2]),
+		}
+
+		// Get documents for this sub-notebook
+		documents, err := s.GetNotebookDocuments(ctx, subNotebook.ID, tenantID)
+		if err == nil {
+			subNotebook.Documents = documents
+		}
+
+		// Recursively get sub-notebooks
+		childNotebooks, err := s.getSubNotebooksRecursive(ctx, subNotebook.ID, tenantID)
+		if err == nil {
+			subNotebook.SubNotebooks = childNotebooks
+		}
+
+		subNotebooks = append(subNotebooks, subNotebook)
+	}
+
+	return subNotebooks, nil
+}
+
+// GetDocumentsRecursive retrieves all documents from a notebook and its sub-notebooks
+func (s *NotebookService) GetDocumentsRecursive(ctx context.Context, notebookID, tenantID string) ([]NotebookDocument, error) {
+	// Use Neo4j's variable-length relationships to get all documents recursively
+	query := `
+		MATCH (n:Notebook {id: $notebook_id, tenant_id: $tenant_id})
+		OPTIONAL MATCH (n)-[:CONTAINS*0..]->(sub:Notebook {tenant_id: $tenant_id})
+		OPTIONAL MATCH (n)-[:CONTAINS]->(d:Document {tenant_id: $tenant_id})
+		OPTIONAL MATCH (sub)-[:CONTAINS]->(sd:Document {tenant_id: $tenant_id})
+		WITH COLLECT(DISTINCT d) + COLLECT(DISTINCT sd) AS allDocs
+		UNWIND allDocs AS doc
+		WITH DISTINCT doc
+		WHERE doc IS NOT NULL
+		MATCH (notebook:Notebook {tenant_id: $tenant_id})-[:CONTAINS]->(doc)
+		RETURN doc.id as id, doc.name as name, doc.file_id as file_id,
+		       doc.content_type as content_type, doc.size_bytes as size_bytes,
+		       doc.chunk_count as chunk_count, doc.created_at as created_at,
+		       notebook.id as notebook_id, notebook.name as notebook_name
+	`
+
+	result, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, map[string]interface{}{
+		"notebook_id": notebookID,
+		"tenant_id":   tenantID,
+	})
+	if err != nil {
+		s.logger.Error("Failed to get documents recursively", zap.Error(err))
+		return nil, errors.InternalWithCause("Failed to get documents recursively", err)
+	}
+
+	var documents []NotebookDocument
+	for _, record := range result.Records {
+		doc := NotebookDocument{
+			ID:           s.getString(record.Values[0]),
+			Name:         s.getString(record.Values[1]),
+			FileID:       s.getString(record.Values[2]),
+			ContentType:  s.getString(record.Values[3]),
+			SizeBytes:    s.getInt64(record.Values[4]),
+			ChunkCount:   s.getInt(record.Values[5]),
+			CreatedAt:    s.getString(record.Values[6]),
+			NotebookID:   s.getString(record.Values[7]),
+			NotebookName: s.getString(record.Values[8]),
+		}
+		documents = append(documents, doc)
+	}
+
+	return documents, nil
+}
+
+// GetSubNotebookIDs retrieves IDs of all sub-notebooks for a parent notebook
+func (s *NotebookService) GetSubNotebookIDs(ctx context.Context, parentNotebookID, tenantID string) ([]string, error) {
+	// Get all sub-notebooks recursively using variable-length relationships
+	query := `
+		MATCH (parent:Notebook {id: $parent_id, tenant_id: $tenant_id})-[:CONTAINS*1..]->(sub:Notebook {tenant_id: $tenant_id})
+		RETURN DISTINCT sub.id as id
+	`
+
+	result, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, map[string]interface{}{
+		"parent_id": parentNotebookID,
+		"tenant_id": tenantID,
+	})
+	if err != nil {
+		s.logger.Error("Failed to get sub-notebook IDs", zap.Error(err))
+		return nil, errors.InternalWithCause("Failed to get sub-notebook IDs", err)
+	}
+
+	var subNotebookIDs []string
+	for _, record := range result.Records {
+		if id := s.getString(record.Values[0]); id != "" {
+			subNotebookIDs = append(subNotebookIDs, id)
+		}
+	}
+
+	return subNotebookIDs, nil
+}
+
+// GetNotebookDocuments retrieves documents for a specific notebook (non-recursive)
+func (s *NotebookService) GetNotebookDocuments(ctx context.Context, notebookID, tenantID string) ([]NotebookDocument, error) {
+	query := `
+		MATCH (n:Notebook {id: $notebook_id, tenant_id: $tenant_id})-[:CONTAINS]->(d:Document {tenant_id: $tenant_id})
+		RETURN d.id as id, d.name as name, d.file_id as file_id,
+		       d.content_type as content_type, d.size_bytes as size_bytes,
+		       d.chunk_count as chunk_count, d.created_at as created_at,
+		       n.id as notebook_id, n.name as notebook_name
+	`
+
+	result, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, map[string]interface{}{
+		"notebook_id": notebookID,
+		"tenant_id":   tenantID,
+	})
+	if err != nil {
+		s.logger.Error("Failed to get notebook documents", zap.Error(err))
+		return nil, errors.InternalWithCause("Failed to get notebook documents", err)
+	}
+
+	var documents []NotebookDocument
+	for _, record := range result.Records {
+		doc := NotebookDocument{
+			ID:           s.getString(record.Values[0]),
+			Name:         s.getString(record.Values[1]),
+			FileID:       s.getString(record.Values[2]),
+			ContentType:  s.getString(record.Values[3]),
+			SizeBytes:    s.getInt64(record.Values[4]),
+			ChunkCount:   s.getInt(record.Values[5]),
+			CreatedAt:    s.getString(record.Values[6]),
+			NotebookID:   s.getString(record.Values[7]),
+			NotebookName: s.getString(record.Values[8]),
+		}
+		documents = append(documents, doc)
+	}
+
+	return documents, nil
 }

--- a/internal/services/production.go
+++ b/internal/services/production.go
@@ -1,0 +1,1441 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"go.uber.org/zap"
+
+	"github.com/Tributary-ai-services/aether-be/internal/database"
+	"github.com/Tributary-ai-services/aether-be/internal/logger"
+	"github.com/Tributary-ai-services/aether-be/internal/models"
+	"github.com/Tributary-ai-services/aether-be/pkg/errors"
+)
+
+// ProductionService handles production-related business logic
+type ProductionService struct {
+	neo4j           *database.Neo4jClient
+	storageService  *S3StorageService
+	agentService    *AgentService
+	notebookService *NotebookService
+	teamService     *TeamService
+	spaceService    *SpaceService
+	audiModal       *AudiModalService
+	logger          *logger.Logger
+}
+
+// NewProductionService creates a new production service
+func NewProductionService(
+	neo4j *database.Neo4jClient,
+	storageService *S3StorageService,
+	agentService *AgentService,
+	notebookService *NotebookService,
+	teamService *TeamService,
+	spaceService *SpaceService,
+	audiModal *AudiModalService,
+	log *logger.Logger,
+) *ProductionService {
+	return &ProductionService{
+		neo4j:           neo4j,
+		storageService:  storageService,
+		agentService:    agentService,
+		notebookService: notebookService,
+		teamService:     teamService,
+		spaceService:    spaceService,
+		audiModal:       audiModal,
+		logger:          log.WithService("production_service"),
+	}
+}
+
+// GetNotebookProducers returns available producer agents for a notebook
+// This includes both internal (system) producer agents and user-created producer agents
+func (s *ProductionService) GetNotebookProducers(ctx context.Context, notebookID, userID, authToken string, spaceCtx *models.SpaceContext) ([]*models.AgentResponse, error) {
+	// Verify notebook exists and user has access
+	_, err := s.notebookService.GetNotebookByID(ctx, notebookID, userID, spaceCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get internal producer agents from agent-builder (these are always available)
+	internalProducers, err := s.agentService.GetInternalProducerAgents(ctx, authToken)
+	if err != nil {
+		s.logger.Error("Failed to get internal producer agents from agent-builder", zap.Error(err))
+		// Don't fail completely - continue with user producers
+		internalProducers = []*models.AgentResponse{}
+	}
+
+	s.logger.Debug("Retrieved internal producer agents",
+		zap.Int("count", len(internalProducers)),
+	)
+
+	// Get all user-created producer agents accessible to this user/space
+	// Filter agents by type=producer and accessible within the space
+	query := `
+		MATCH (a:Agent)
+		WHERE a.type = 'producer'
+			AND a.status = 'published'
+			AND a.tenant_id = $tenant_id
+			AND (
+				a.space_id = $space_id
+				OR a.is_public = true
+			)
+		OPTIONAL MATCH (a)-[:OWNED_BY]->(owner:User)
+		RETURN a.id, a.agent_builder_id, a.name, a.description, a.status, a.type,
+		       a.owner_id, a.space_type, a.space_id, a.tenant_id, a.team_id,
+		       a.is_public, a.is_template, a.tags, a.created_at, a.updated_at,
+		       owner.username, owner.full_name, owner.avatar_url
+		ORDER BY a.name ASC
+	`
+
+	params := map[string]interface{}{
+		"tenant_id": spaceCtx.TenantID,
+		"space_id":  spaceCtx.SpaceID,
+	}
+
+	result, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, params)
+	if err != nil {
+		s.logger.Error("Failed to get notebook producers from Neo4j", zap.Error(err))
+		return nil, errors.Database("Failed to get notebook producers", err)
+	}
+
+	// Parse user-created producer agents from Neo4j
+	userProducers := make([]*models.AgentResponse, 0, len(result.Records))
+	for _, record := range result.Records {
+		agent, err := s.recordToAgentResponse(record)
+		if err != nil {
+			s.logger.Error("Failed to parse agent record", zap.Error(err))
+			continue
+		}
+		userProducers = append(userProducers, agent)
+	}
+
+	s.logger.Debug("Retrieved user-created producer agents",
+		zap.Int("count", len(userProducers)),
+	)
+
+	// Merge: internal agents first, then user-created agents
+	allProducers := make([]*models.AgentResponse, 0, len(internalProducers)+len(userProducers))
+	allProducers = append(allProducers, internalProducers...)
+	allProducers = append(allProducers, userProducers...)
+
+	s.logger.Info("Returning all producer agents for notebook",
+		zap.String("notebook_id", notebookID),
+		zap.Int("internal_count", len(internalProducers)),
+		zap.Int("user_count", len(userProducers)),
+		zap.Int("total_count", len(allProducers)),
+	)
+
+	return allProducers, nil
+}
+
+// ExecuteProducer executes a producer agent on a notebook and creates a production
+func (s *ProductionService) ExecuteProducer(ctx context.Context, notebookID string, req models.ProducerExecuteRequest, userID string, userTeams []string, authToken string, spaceCtx *models.SpaceContext) (*models.ProductionResponse, error) {
+	// Verify notebook exists and user has access
+	notebook, err := s.notebookService.GetNotebookByID(ctx, notebookID, userID, spaceCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	var agent *models.AgentResponse
+	var isInternalAgent bool
+
+	// Check if this is an internal producer agent first (from agent-builder)
+	internalAgent, err := s.agentService.GetInternalAgentByID(ctx, req.AgentID, authToken)
+	if err != nil {
+		s.logger.Warn("Error checking for internal agent, trying user agent",
+			zap.Error(err),
+			zap.String("agent_id", req.AgentID),
+		)
+	}
+
+	if internalAgent != nil {
+		// Verify internal agent is a producer type
+		if internalAgent.Type != models.AgentTypeProducer {
+			return nil, errors.BadRequestWithDetails("Agent is not a producer type", map[string]interface{}{
+				"agent_id":   req.AgentID,
+				"agent_type": internalAgent.Type,
+			})
+		}
+		agent = internalAgent
+		isInternalAgent = true
+		s.logger.Info("Using internal producer agent",
+			zap.String("agent_id", agent.ID),
+			zap.String("agent_name", agent.Name),
+		)
+	} else {
+		// Get the agent using the agent service (from Neo4j)
+		agent, err = s.agentService.GetAgent(ctx, req.AgentID, userID, userTeams)
+		if err != nil {
+			return nil, errors.NotFoundWithDetails("Agent not found", map[string]interface{}{
+				"agent_id": req.AgentID,
+			})
+		}
+
+		// Verify agent is a producer type
+		if agent.Type != models.AgentTypeProducer {
+			return nil, errors.BadRequestWithDetails("Agent is not a producer type", map[string]interface{}{
+				"agent_id":   req.AgentID,
+				"agent_type": agent.Type,
+			})
+		}
+
+		// Verify agent is published
+		if agent.Status != models.AgentStatusPublished {
+			return nil, errors.BadRequestWithDetails("Agent is not published", map[string]interface{}{
+				"agent_id":     req.AgentID,
+				"agent_status": agent.Status,
+			})
+		}
+		isInternalAgent = false
+	}
+
+	// Create production record in processing status
+	production := models.NewProduction(req, agent.ID, agent.AgentBuilderID, notebookID, userID, spaceCtx)
+
+	// Store production in Neo4j
+	if err := s.createProduction(ctx, production); err != nil {
+		return nil, err
+	}
+
+	// Execute the agent asynchronously (in a goroutine)
+	// For now, we do it synchronously for simplicity
+	startTime := time.Now()
+
+	var output string
+	var tokensUsed int
+	var costUSD float64
+	var executionID string
+
+	if isInternalAgent {
+		// Execute internal agent directly via LLM router
+		output, err = s.executeInternalProducerAgent(ctx, agent, notebook, req, authToken, spaceCtx)
+		if err != nil {
+			// Mark production as failed
+			production.MarkFailed(err.Error())
+			if updateErr := s.updateProduction(ctx, production); updateErr != nil {
+				s.logger.Error("Failed to update production status to failed", zap.Error(updateErr))
+			}
+			return nil, errors.InternalWithCause("Internal agent execution failed", err)
+		}
+		executionID = production.ID // Use production ID as execution ID for internal agents
+		// Note: tokensUsed and costUSD will be 0 for internal agents as we don't track them yet
+	} else {
+		// Build the execute request for user-created agents
+		formatStr := string(req.Format)
+		executeReq := models.AgentExecuteRequest{
+			Input:        fmt.Sprintf("Generate a %s for notebook: %s", req.Type, notebook.Name),
+			Context:      req.Context,
+			Sources:      []string{notebookID},
+			OutputFormat: &formatStr,
+		}
+
+		if len(req.SourceDocuments) > 0 {
+			if executeReq.Context == nil {
+				executeReq.Context = make(map[string]interface{})
+			}
+			executeReq.Context["document_ids"] = req.SourceDocuments
+		}
+
+		// Execute the agent via agent service
+		executeResp, execErr := s.agentService.ExecuteAgent(ctx, agent.ID, executeReq, userID, userTeams, authToken)
+		if execErr != nil {
+			// Mark production as failed
+			production.MarkFailed(execErr.Error())
+			if updateErr := s.updateProduction(ctx, production); updateErr != nil {
+				s.logger.Error("Failed to update production status to failed", zap.Error(updateErr))
+			}
+			return nil, errors.InternalWithCause("Agent execution failed", execErr)
+		}
+		output = executeResp.Output
+		tokensUsed = executeResp.TokensUsed
+		costUSD = executeResp.CostUSD
+		executionID = executeResp.ExecutionID
+	}
+
+	responseTimeMs := int(time.Since(startTime).Milliseconds())
+
+	// Generate content from agent output
+	content := output
+	contentBytes := []byte(content)
+
+	// Generate filename based on type and format
+	filename := fmt.Sprintf("%s_%s.%s", req.Type, time.Now().Format("2006-01-02"), getFileExtension(req.Format))
+	storageKey := models.BuildProductionStorageKey(string(spaceCtx.SpaceType), notebookID, production.ID, filename)
+
+	// Upload content to S3
+	contentType := getContentType(req.Format)
+	_, err = s.storageService.UploadFileToTenantBucket(ctx, spaceCtx.TenantID, storageKey, contentBytes, contentType)
+	if err != nil {
+		s.logger.Error("Failed to upload production content to S3", zap.Error(err))
+		production.MarkFailed("Failed to store production content: " + err.Error())
+		if updateErr := s.updateProduction(ctx, production); updateErr != nil {
+			s.logger.Error("Failed to update production status", zap.Error(updateErr))
+		}
+		return nil, errors.InternalWithCause("Failed to store production content", err)
+	}
+
+	// Update production with completion details
+	production.MarkCompleted(
+		storageKey,
+		fmt.Sprintf("aether-%s", extractTenantSuffix(spaceCtx.TenantID)),
+		int64(len(contentBytes)),
+		executionID,
+		tokensUsed,
+		costUSD,
+		responseTimeMs,
+	)
+
+	// Update production in Neo4j
+	if err := s.updateProduction(ctx, production); err != nil {
+		s.logger.Error("Failed to update production status", zap.Error(err))
+		return nil, err
+	}
+
+	// Create relationships
+	if err := s.createProductionRelationships(ctx, production, spaceCtx.TenantID); err != nil {
+		s.logger.Error("Failed to create production relationships", zap.Error(err))
+		// Don't fail the whole operation for relationship errors
+	}
+
+	s.logger.Info("Production created successfully",
+		zap.String("production_id", production.ID),
+		zap.String("notebook_id", notebookID),
+		zap.String("agent_id", agent.ID),
+		zap.String("type", string(req.Type)),
+	)
+
+	response := production.ToResponse()
+	response.Content = content // Include content in response
+	return response, nil
+}
+
+// executeInternalProducerAgent executes an internal producer agent via agent-builder
+// This leverages agent-builder's document context retrieval capabilities
+func (s *ProductionService) executeInternalProducerAgent(
+	ctx context.Context,
+	agent *models.AgentResponse,
+	notebook *models.Notebook,
+	req models.ProducerExecuteRequest,
+	authToken string,
+	spaceCtx *models.SpaceContext,
+) (string, error) {
+	// Build the user message based on production type and notebook context
+	// Note: We don't include document content here since agent-builder will inject it
+	userMessage := s.buildProducerUserMessage(notebook, req, "")
+
+	// Resolve Aether tenant ID to AudiModal UUID
+	// The notebook has an internal tenant ID (e.g., "tenant_1766596584") that needs to be
+	// resolved to an AudiModal UUID. This may create a new AudiModal tenant if one doesn't exist.
+	var audimodalTenantID string
+	if s.audiModal != nil {
+		resolvedUUID, err := s.audiModal.GetAudiModalTenantUUID(ctx, notebook.TenantID)
+		if err != nil {
+			s.logger.Warn("Failed to resolve AudiModal tenant UUID, falling back to extracting from tenant ID",
+				zap.String("notebook_tenant_id", notebook.TenantID),
+				zap.Error(err))
+			// Fallback: extract UUID from tenant_<UUID> format if it's already a UUID
+			audimodalTenantID = extractTenantSuffix(notebook.TenantID)
+		} else {
+			audimodalTenantID = resolvedUUID
+			s.logger.Debug("Resolved AudiModal tenant UUID",
+				zap.String("notebook_tenant_id", notebook.TenantID),
+				zap.String("audimodal_tenant_uuid", audimodalTenantID))
+		}
+	} else {
+		// No AudiModalService available - try to extract UUID from tenant ID
+		audimodalTenantID = extractTenantSuffix(notebook.TenantID)
+		s.logger.Warn("AudiModalService not available, using extracted tenant ID",
+			zap.String("audimodal_tenant_id", audimodalTenantID))
+	}
+
+	// Get AudiModal file IDs for documents in the notebook
+	// Agent-builder needs these file IDs to fetch chunks from AudiModal
+	var audimodalFileIDs []string
+	if len(req.SourceDocuments) > 0 {
+		// User specified specific documents - get their AudiModal file IDs
+		audimodalFileIDs, _ = s.getAudiModalFileIDs(ctx, notebook.TenantID, req.SourceDocuments)
+	} else {
+		// No specific documents - get all documents from the notebook
+		audimodalFileIDs, _ = s.getNotebookAudiModalFileIDs(ctx, notebook.ID, notebook.TenantID)
+	}
+
+	s.logger.Debug("Retrieved AudiModal file IDs for producer execution",
+		zap.String("notebook_id", notebook.ID),
+		zap.Int("file_id_count", len(audimodalFileIDs)),
+		zap.Strings("file_ids", audimodalFileIDs))
+
+	// Build the execution request for agent-builder
+	// This passes notebook IDs and file IDs so agent-builder can retrieve document context
+	executeReq := InternalAgentExecuteRequest{
+		Input:       userMessage,
+		NotebookIDs: []string{notebook.ID},
+		TenantID:    audimodalTenantID,
+	}
+
+	// Add AudiModal file IDs so agent-builder can fetch chunks
+	if len(audimodalFileIDs) > 0 {
+		executeReq.SelectedDocuments = audimodalFileIDs
+	}
+
+	s.logger.Info("Executing internal producer agent via agent-builder",
+		zap.String("agent_id", agent.ID),
+		zap.String("agent_name", agent.Name),
+		zap.String("notebook_id", notebook.ID),
+		zap.String("audimodal_tenant_id", audimodalTenantID),
+		zap.String("internal_tenant_id", notebook.TenantID),
+		zap.Int("source_documents", len(req.SourceDocuments)),
+	)
+
+	// Execute via agent-builder which will:
+	// 1. Retrieve document context from DeepLake/AudiModal based on notebook IDs
+	// 2. Inject the context into the system prompt
+	// 3. Call the LLM with the enriched prompt
+	response, err := s.agentService.ExecuteInternalAgent(ctx, agent.ID, executeReq, authToken)
+	if err != nil {
+		s.logger.Error("Failed to execute internal producer agent via agent-builder",
+			zap.String("agent_id", agent.ID),
+			zap.String("agent_name", agent.Name),
+			zap.Error(err))
+		return "", err
+	}
+
+	s.logger.Info("Internal producer agent executed successfully via agent-builder",
+		zap.String("agent_id", agent.ID),
+		zap.String("agent_name", agent.Name),
+		zap.String("notebook_id", notebook.ID),
+		zap.String("execution_id", response.ExecutionID),
+		zap.Int("output_length", len(response.Output)),
+		zap.Int("tokens_used", response.TokensUsed),
+	)
+
+	return response.Output, nil
+}
+
+// getNotebookDocumentContent retrieves the extracted text content from documents in a notebook
+func (s *ProductionService) getNotebookDocumentContent(ctx context.Context, notebookID, tenantID string, sourceDocumentIDs []string) (string, error) {
+	var query string
+	params := map[string]interface{}{
+		"notebook_id": notebookID,
+		"tenant_id":   tenantID,
+	}
+
+	// If specific source documents are requested, only get those
+	if len(sourceDocumentIDs) > 0 {
+		query = `
+			MATCH (d:Document {tenant_id: $tenant_id})
+			WHERE d.id IN $document_ids AND d.extracted_text IS NOT NULL AND d.extracted_text <> ''
+			RETURN d.id as id, d.name as name, d.extracted_text as content
+			ORDER BY d.name
+		`
+		params["document_ids"] = sourceDocumentIDs
+	} else {
+		// Get all documents in the notebook
+		query = `
+			MATCH (n:Notebook {id: $notebook_id, tenant_id: $tenant_id})-[:CONTAINS]->(d:Document {tenant_id: $tenant_id})
+			WHERE d.extracted_text IS NOT NULL AND d.extracted_text <> ''
+			RETURN d.id as id, d.name as name, d.extracted_text as content
+			ORDER BY d.name
+		`
+	}
+
+	result, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, params)
+	if err != nil {
+		return "", fmt.Errorf("failed to query documents: %w", err)
+	}
+
+	if len(result.Records) == 0 {
+		s.logger.Info("No documents with extracted text found",
+			zap.String("notebook_id", notebookID),
+			zap.Int("source_docs_requested", len(sourceDocumentIDs)),
+		)
+		return "", nil
+	}
+
+	// Build combined content from all documents
+	var contentBuilder strings.Builder
+	contentBuilder.WriteString("=== DOCUMENT CONTENT ===\n\n")
+
+	for i, record := range result.Records {
+		name := ""
+		content := ""
+
+		if record.Values[1] != nil {
+			name = fmt.Sprintf("%v", record.Values[1])
+		}
+		if record.Values[2] != nil {
+			content = fmt.Sprintf("%v", record.Values[2])
+		}
+
+		if content != "" {
+			contentBuilder.WriteString(fmt.Sprintf("--- Document %d: %s ---\n", i+1, name))
+			contentBuilder.WriteString(content)
+			contentBuilder.WriteString("\n\n")
+		}
+	}
+
+	contentBuilder.WriteString("=== END OF DOCUMENTS ===\n")
+
+	s.logger.Debug("Built document content",
+		zap.Int("document_count", len(result.Records)),
+		zap.Int("total_content_length", contentBuilder.Len()),
+	)
+
+	return contentBuilder.String(), nil
+}
+
+// processingResultJSON represents the structure of the processing_result JSON string
+type processingResultJSON struct {
+	AudiModalFileID string `json:"audimodal_file_id"`
+}
+
+// getNotebookAudiModalFileIDs retrieves AudiModal file IDs for all processed documents in a notebook
+// Note: processing_result is stored as a JSON string in Neo4j, so we need to parse it in Go
+// Note: Documents are linked to notebooks via notebook_id property, not CONTAINS relationship
+func (s *ProductionService) getNotebookAudiModalFileIDs(ctx context.Context, notebookID, tenantID string) ([]string, error) {
+	// Query for documents with processing_result (stored as JSON string)
+	// Documents are linked via notebook_id property and filtered by status
+	query := `
+		MATCH (d:Document {notebook_id: $notebook_id, tenant_id: $tenant_id})
+		WHERE d.processing_result IS NOT NULL
+		  AND d.status IN ['processed', 'ready']
+		RETURN d.id as id, d.name as name, d.processing_result as processing_result, d.status as status
+		ORDER BY d.name
+	`
+	params := map[string]any{
+		"notebook_id": notebookID,
+		"tenant_id":   tenantID,
+	}
+
+	result, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, params)
+	if err != nil {
+		s.logger.Error("Failed to query documents for AudiModal file IDs",
+			zap.String("notebook_id", notebookID),
+			zap.Error(err))
+		return nil, fmt.Errorf("failed to query documents: %w", err)
+	}
+
+	s.logger.Info("Found documents in notebook",
+		zap.String("notebook_id", notebookID),
+		zap.Int("document_count", len(result.Records)))
+
+	var fileIDs []string
+	for _, record := range result.Records {
+		docName := fmt.Sprintf("%v", record.Values[1])
+		processingResultStr := fmt.Sprintf("%v", record.Values[2])
+		status := fmt.Sprintf("%v", record.Values[3])
+
+		// Parse the processing_result JSON string to extract audimodal_file_id
+		var pr processingResultJSON
+		if err := json.Unmarshal([]byte(processingResultStr), &pr); err != nil {
+			s.logger.Debug("Failed to parse processing_result JSON",
+				zap.String("document_name", docName),
+				zap.String("status", status),
+				zap.Error(err))
+			continue
+		}
+
+		if pr.AudiModalFileID != "" {
+			fileIDs = append(fileIDs, pr.AudiModalFileID)
+			s.logger.Debug("Found AudiModal file ID for document",
+				zap.String("document_name", docName),
+				zap.String("audimodal_file_id", pr.AudiModalFileID),
+				zap.String("status", status))
+		} else {
+			s.logger.Debug("Document has no audimodal_file_id in processing_result",
+				zap.String("document_name", docName),
+				zap.String("status", status))
+		}
+	}
+
+	s.logger.Info("Retrieved AudiModal file IDs from notebook",
+		zap.String("notebook_id", notebookID),
+		zap.Int("total_documents", len(result.Records)),
+		zap.Int("documents_with_file_ids", len(fileIDs)))
+
+	return fileIDs, nil
+}
+
+// getAudiModalFileIDs retrieves AudiModal file IDs for specific document IDs
+// Note: processing_result is stored as a JSON string in Neo4j, so we need to parse it in Go
+func (s *ProductionService) getAudiModalFileIDs(ctx context.Context, tenantID string, documentIDs []string) ([]string, error) {
+	query := `
+		MATCH (d:Document {tenant_id: $tenant_id})
+		WHERE d.id IN $document_ids
+		  AND d.processing_result IS NOT NULL
+		RETURN d.id as id, d.name as name, d.processing_result as processing_result, d.status as status
+		ORDER BY d.name
+	`
+	params := map[string]any{
+		"tenant_id":    tenantID,
+		"document_ids": documentIDs,
+	}
+
+	result, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, params)
+	if err != nil {
+		s.logger.Error("Failed to query specific documents for AudiModal file IDs",
+			zap.Int("document_count", len(documentIDs)),
+			zap.Error(err))
+		return nil, fmt.Errorf("failed to query documents: %w", err)
+	}
+
+	var fileIDs []string
+	for _, record := range result.Records {
+		docName := fmt.Sprintf("%v", record.Values[1])
+		processingResultStr := fmt.Sprintf("%v", record.Values[2])
+		status := fmt.Sprintf("%v", record.Values[3])
+
+		// Parse the processing_result JSON string to extract audimodal_file_id
+		var pr processingResultJSON
+		if err := json.Unmarshal([]byte(processingResultStr), &pr); err != nil {
+			s.logger.Debug("Failed to parse processing_result JSON for document",
+				zap.String("document_name", docName),
+				zap.String("status", status),
+				zap.Error(err))
+			continue
+		}
+
+		if pr.AudiModalFileID != "" {
+			fileIDs = append(fileIDs, pr.AudiModalFileID)
+			s.logger.Debug("Found AudiModal file ID for specific document",
+				zap.String("document_name", docName),
+				zap.String("audimodal_file_id", pr.AudiModalFileID),
+				zap.String("status", status))
+		}
+	}
+
+	s.logger.Info("Retrieved AudiModal file IDs for specific documents",
+		zap.Int("requested_documents", len(documentIDs)),
+		zap.Int("found_documents", len(result.Records)),
+		zap.Int("documents_with_file_ids", len(fileIDs)))
+
+	return fileIDs, nil
+}
+
+// buildProducerUserMessage builds the user message for producer agents based on the request
+// Note: documentContent parameter is kept for backwards compatibility but is typically empty
+// when using agent-builder's document context injection (which happens at the system prompt level)
+func (s *ProductionService) buildProducerUserMessage(notebook *models.Notebook, req models.ProducerExecuteRequest, documentContent string) string {
+	var message string
+
+	// Build message based on production type
+	// Note: When using agent-builder, document content is injected into the system prompt,
+	// so user messages must explicitly reference "the documents provided above in the context"
+	// IMPORTANT: We must be very explicit that the LLM should use ONLY the document content,
+	// not make up content based on the notebook name/description
+	switch req.Type {
+	case models.ProductionTypeSummary:
+		message = "IMPORTANT: You MUST use ONLY the document content provided above in the '--- RELEVANT CONTEXT ---' section. Do NOT make up or infer content.\n\n"
+		message += fmt.Sprintf("Generate a comprehensive summary of the documents in the notebook \"%s\".\n\n", notebook.Name)
+		message += "Your summary must be based EXCLUSIVELY on the actual text content from the documents provided above. Include specific facts, figures, names, and details from those documents. Do not generate generic content."
+
+	case models.ProductionTypeQA:
+		message = "IMPORTANT: You MUST use ONLY the document content provided above in the '--- RELEVANT CONTEXT ---' section. Do NOT make up or infer content.\n\n"
+		message += fmt.Sprintf("Generate question and answer pairs based on the documents in the notebook \"%s\".\n\n", notebook.Name)
+		message += "All questions and answers must be derived EXCLUSIVELY from the actual text content in the documents provided above. Reference specific information from those documents."
+
+	case models.ProductionTypeOutline:
+		message = "IMPORTANT: You MUST use ONLY the document content provided above in the '--- RELEVANT CONTEXT ---' section. Do NOT make up or infer content.\n\n"
+		message += fmt.Sprintf("Create a structured outline of the documents in the notebook \"%s\".\n\n", notebook.Name)
+		message += "The outline must reflect the ACTUAL content and topics from the documents provided above. Organize the real information from those documents into a hierarchical structure with sections and key points."
+
+	case models.ProductionTypeInsight:
+		message = "IMPORTANT: You MUST use ONLY the document content provided above in the '--- RELEVANT CONTEXT ---' section. Do NOT make up or infer content.\n\n"
+		message += fmt.Sprintf("Extract key insights and actionable takeaways from the documents in the notebook \"%s\".\n\n", notebook.Name)
+		message += "All insights must be derived EXCLUSIVELY from the actual text content in the documents provided above. Cite specific evidence from those documents."
+
+	default:
+		message = "IMPORTANT: You MUST use ONLY the document content provided above in the '--- RELEVANT CONTEXT ---' section. Do NOT make up or infer content.\n\n"
+		message += fmt.Sprintf("Analyze the documents in the notebook \"%s\" and generate content of type \"%s\".\n\n", notebook.Name, req.Type)
+		message += "Base your response EXCLUSIVELY on the actual document content provided above."
+	}
+
+	// Add format instruction if specified
+	if req.Format != "" {
+		message += fmt.Sprintf("\n\nPlease format the output as %s.", req.Format)
+	}
+
+	// Add custom title if provided
+	if req.Title != "" {
+		message += fmt.Sprintf("\n\nTitle the output: \"%s\"", req.Title)
+	}
+
+	// Include document content if explicitly provided (for direct LLM execution fallback)
+	// When using agent-builder, document context is injected into the system prompt,
+	// so this will typically be empty
+	if documentContent != "" {
+		message += "\n\nBelow is the content from the documents in this notebook. Use this content to generate your response:\n\n"
+		message += documentContent
+	}
+
+	return message
+}
+
+// GetProductionByID retrieves a production by ID
+func (s *ProductionService) GetProductionByID(ctx context.Context, productionID, userID string, spaceCtx *models.SpaceContext) (*models.Production, error) {
+	query := `
+		MATCH (p:Production {id: $production_id, tenant_id: $tenant_id})
+		RETURN p.id, p.title, p.type, p.format, p.status,
+		       p.agent_id, p.agent_builder_id, p.notebook_id, p.user_id,
+		       p.space_type, p.space_id, p.tenant_id,
+		       p.storage_bucket, p.storage_key, p.size_bytes,
+		       p.execution_id, p.tokens_used, p.cost_usd, p.response_time_ms,
+		       p.error_message, p.source_documents, p.search_text,
+		       p.created_at, p.updated_at
+	`
+
+	params := map[string]interface{}{
+		"production_id": productionID,
+		"tenant_id":     spaceCtx.TenantID,
+	}
+
+	result, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, params)
+	if err != nil {
+		s.logger.Error("Failed to get production by ID", zap.String("production_id", productionID), zap.Error(err))
+		return nil, errors.Database("Failed to retrieve production", err)
+	}
+
+	if len(result.Records) == 0 {
+		return nil, errors.NotFoundWithDetails("Production not found", map[string]interface{}{
+			"production_id": productionID,
+		})
+	}
+
+	production, err := s.recordToProduction(result.Records[0])
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify production belongs to the correct space
+	if production.SpaceID != spaceCtx.SpaceID || production.TenantID != spaceCtx.TenantID {
+		return nil, errors.ForbiddenWithDetails("Production not accessible in this space", map[string]interface{}{
+			"production_id": productionID,
+			"space_id":      spaceCtx.SpaceID,
+		})
+	}
+
+	// Check if user has read permissions
+	if !spaceCtx.CanRead() {
+		return nil, errors.Forbidden("Insufficient permissions to read production")
+	}
+
+	return production, nil
+}
+
+// GetProductionContent retrieves the content of a production from S3
+func (s *ProductionService) GetProductionContent(ctx context.Context, productionID, userID string, spaceCtx *models.SpaceContext) (string, error) {
+	production, err := s.GetProductionByID(ctx, productionID, userID, spaceCtx)
+	if err != nil {
+		return "", err
+	}
+
+	if production.StorageKey == "" {
+		return "", errors.NotFoundWithDetails("Production content not available", map[string]interface{}{
+			"production_id": productionID,
+			"status":        production.Status,
+		})
+	}
+
+	// Download content from S3
+	content, err := s.storageService.DownloadFileFromTenantBucket(ctx, spaceCtx.TenantID, production.StorageKey)
+	if err != nil {
+		s.logger.Error("Failed to download production content", zap.Error(err))
+		return "", errors.InternalWithCause("Failed to retrieve production content", err)
+	}
+
+	return string(content), nil
+}
+
+// ListNotebookProductions lists productions for a notebook
+func (s *ProductionService) ListNotebookProductions(ctx context.Context, notebookID, userID string, spaceCtx *models.SpaceContext, limit, offset int) (*models.ProductionListResponse, error) {
+	// Verify notebook exists and user has access
+	_, err := s.notebookService.GetNotebookByID(ctx, notebookID, userID, spaceCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set defaults
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	query := `
+		MATCH (p:Production)
+		WHERE p.notebook_id = $notebook_id
+			AND p.tenant_id = $tenant_id
+			AND p.space_id = $space_id
+		RETURN p.id, p.title, p.type, p.format, p.status,
+		       p.agent_id, p.agent_builder_id, p.notebook_id, p.user_id,
+		       p.space_type, p.space_id, p.tenant_id,
+		       p.storage_bucket, p.storage_key, p.size_bytes,
+		       p.execution_id, p.tokens_used, p.cost_usd, p.response_time_ms,
+		       p.error_message, p.source_documents, p.created_at, p.updated_at
+		ORDER BY p.created_at DESC
+		SKIP $offset
+		LIMIT $limit
+	`
+
+	params := map[string]interface{}{
+		"notebook_id": notebookID,
+		"tenant_id":   spaceCtx.TenantID,
+		"space_id":    spaceCtx.SpaceID,
+		"limit":       limit + 1,
+		"offset":      offset,
+	}
+
+	result, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, params)
+	if err != nil {
+		s.logger.Error("Failed to list notebook productions", zap.Error(err))
+		return nil, errors.Database("Failed to list productions", err)
+	}
+
+	productions := make([]*models.ProductionResponse, 0, len(result.Records))
+	hasMore := false
+
+	for i, record := range result.Records {
+		if i >= limit {
+			hasMore = true
+			break
+		}
+
+		production, err := s.recordToProduction(record)
+		if err != nil {
+			s.logger.Error("Failed to parse production record", zap.Error(err))
+			continue
+		}
+		productions = append(productions, production.ToResponse())
+	}
+
+	// Get total count
+	countQuery := `
+		MATCH (p:Production)
+		WHERE p.notebook_id = $notebook_id
+			AND p.tenant_id = $tenant_id
+			AND p.space_id = $space_id
+		RETURN count(p) as total
+	`
+
+	countResult, err := s.neo4j.ExecuteQueryWithLogging(ctx, countQuery, map[string]interface{}{
+		"notebook_id": notebookID,
+		"tenant_id":   spaceCtx.TenantID,
+		"space_id":    spaceCtx.SpaceID,
+	})
+	if err != nil {
+		s.logger.Error("Failed to get production count", zap.Error(err))
+		return nil, errors.Database("Failed to get production count", err)
+	}
+
+	total := 0
+	if len(countResult.Records) > 0 {
+		if totalValue, found := countResult.Records[0].Get("total"); found {
+			if totalInt, ok := totalValue.(int64); ok {
+				total = int(totalInt)
+			}
+		}
+	}
+
+	return &models.ProductionListResponse{
+		Productions: productions,
+		Total:       total,
+		Limit:       limit,
+		Offset:      offset,
+		HasMore:     hasMore,
+	}, nil
+}
+
+// DeleteProduction deletes a production
+func (s *ProductionService) DeleteProduction(ctx context.Context, productionID, userID string, spaceCtx *models.SpaceContext) error {
+	production, err := s.GetProductionByID(ctx, productionID, userID, spaceCtx)
+	if err != nil {
+		return err
+	}
+
+	// Check if user can delete
+	if !spaceCtx.CanDelete() {
+		return errors.Forbidden("Insufficient permissions to delete production")
+	}
+
+	// Delete from S3 first
+	if production.StorageKey != "" {
+		if err := s.storageService.DeleteFileFromTenantBucket(ctx, spaceCtx.TenantID, production.StorageKey); err != nil {
+			s.logger.Warn("Failed to delete production content from S3", zap.Error(err))
+			// Continue with Neo4j deletion even if S3 deletion fails
+		}
+	}
+
+	// Delete from Neo4j
+	query := `
+		MATCH (p:Production {id: $production_id, tenant_id: $tenant_id})
+		DETACH DELETE p
+	`
+
+	params := map[string]interface{}{
+		"production_id": productionID,
+		"tenant_id":     spaceCtx.TenantID,
+	}
+
+	_, err = s.neo4j.ExecuteQueryWithLogging(ctx, query, params)
+	if err != nil {
+		s.logger.Error("Failed to delete production", zap.String("production_id", productionID), zap.Error(err))
+		return errors.Database("Failed to delete production", err)
+	}
+
+	s.logger.Info("Production deleted successfully",
+		zap.String("production_id", productionID),
+		zap.String("title", production.Title),
+	)
+
+	return nil
+}
+
+// Helper methods
+
+func (s *ProductionService) createProduction(ctx context.Context, production *models.Production) error {
+	query := `
+		CREATE (p:Production {
+			id: $id,
+			title: $title,
+			type: $type,
+			format: $format,
+			status: $status,
+			agent_id: $agent_id,
+			agent_builder_id: $agent_builder_id,
+			notebook_id: $notebook_id,
+			user_id: $user_id,
+			space_type: $space_type,
+			space_id: $space_id,
+			tenant_id: $tenant_id,
+			storage_bucket: $storage_bucket,
+			storage_key: $storage_key,
+			size_bytes: $size_bytes,
+			execution_id: $execution_id,
+			tokens_used: $tokens_used,
+			cost_usd: $cost_usd,
+			response_time_ms: $response_time_ms,
+			error_message: $error_message,
+			source_documents: $source_documents,
+			search_text: $search_text,
+			created_at: datetime($created_at),
+			updated_at: datetime($updated_at)
+		})
+		RETURN p
+	`
+
+	params := map[string]interface{}{
+		"id":               production.ID,
+		"title":            production.Title,
+		"type":             string(production.Type),
+		"format":           string(production.Format),
+		"status":           string(production.Status),
+		"agent_id":         production.AgentID,
+		"agent_builder_id": production.AgentBuilderID,
+		"notebook_id":      production.NotebookID,
+		"user_id":          production.UserID,
+		"space_type":       string(production.SpaceType),
+		"space_id":         production.SpaceID,
+		"tenant_id":        production.TenantID,
+		"storage_bucket":   production.StorageBucket,
+		"storage_key":      production.StorageKey,
+		"size_bytes":       production.SizeBytes,
+		"execution_id":     production.ExecutionID,
+		"tokens_used":      production.TokensUsed,
+		"cost_usd":         production.CostUSD,
+		"response_time_ms": production.ResponseTimeMs,
+		"error_message":    production.ErrorMessage,
+		"source_documents": production.SourceDocuments,
+		"search_text":      production.SearchText,
+		"created_at":       production.CreatedAt.Format(time.RFC3339),
+		"updated_at":       production.UpdatedAt.Format(time.RFC3339),
+	}
+
+	_, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, params)
+	if err != nil {
+		s.logger.Error("Failed to create production", zap.Error(err))
+		return errors.Database("Failed to create production", err)
+	}
+
+	return nil
+}
+
+func (s *ProductionService) updateProduction(ctx context.Context, production *models.Production) error {
+	query := `
+		MATCH (p:Production {id: $id, tenant_id: $tenant_id})
+		SET p.title = $title,
+		    p.status = $status,
+		    p.storage_bucket = $storage_bucket,
+		    p.storage_key = $storage_key,
+		    p.size_bytes = $size_bytes,
+		    p.execution_id = $execution_id,
+		    p.tokens_used = $tokens_used,
+		    p.cost_usd = $cost_usd,
+		    p.response_time_ms = $response_time_ms,
+		    p.error_message = $error_message,
+		    p.search_text = $search_text,
+		    p.updated_at = datetime($updated_at)
+		RETURN p
+	`
+
+	params := map[string]interface{}{
+		"id":               production.ID,
+		"tenant_id":        production.TenantID,
+		"title":            production.Title,
+		"status":           string(production.Status),
+		"storage_bucket":   production.StorageBucket,
+		"storage_key":      production.StorageKey,
+		"size_bytes":       production.SizeBytes,
+		"execution_id":     production.ExecutionID,
+		"tokens_used":      production.TokensUsed,
+		"cost_usd":         production.CostUSD,
+		"response_time_ms": production.ResponseTimeMs,
+		"error_message":    production.ErrorMessage,
+		"search_text":      production.SearchText,
+		"updated_at":       production.UpdatedAt.Format(time.RFC3339),
+	}
+
+	_, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, params)
+	if err != nil {
+		s.logger.Error("Failed to update production", zap.Error(err))
+		return errors.Database("Failed to update production", err)
+	}
+
+	return nil
+}
+
+func (s *ProductionService) createProductionRelationships(ctx context.Context, production *models.Production, tenantID string) error {
+	// Create BELONGS_TO relationship to Notebook
+	notebookRelQuery := `
+		MATCH (p:Production {id: $production_id, tenant_id: $tenant_id}),
+		      (n:Notebook {id: $notebook_id, tenant_id: $tenant_id})
+		MERGE (p)-[r:BELONGS_TO]->(n)
+		ON CREATE SET r.created_at = datetime()
+	`
+	_, err := s.neo4j.ExecuteQueryWithLogging(ctx, notebookRelQuery, map[string]interface{}{
+		"production_id": production.ID,
+		"notebook_id":   production.NotebookID,
+		"tenant_id":     tenantID,
+	})
+	if err != nil {
+		s.logger.Warn("Failed to create BELONGS_TO relationship", zap.Error(err))
+	}
+
+	// Create CREATED_BY relationship to Agent
+	agentRelQuery := `
+		MATCH (p:Production {id: $production_id, tenant_id: $tenant_id}),
+		      (a:Agent {id: $agent_id, tenant_id: $tenant_id})
+		MERGE (p)-[r:CREATED_BY]->(a)
+		ON CREATE SET r.created_at = datetime()
+	`
+	_, err = s.neo4j.ExecuteQueryWithLogging(ctx, agentRelQuery, map[string]interface{}{
+		"production_id": production.ID,
+		"agent_id":      production.AgentID,
+		"tenant_id":     tenantID,
+	})
+	if err != nil {
+		s.logger.Warn("Failed to create CREATED_BY relationship", zap.Error(err))
+	}
+
+	// Create OWNED_BY relationship to User
+	userRelQuery := `
+		MATCH (p:Production {id: $production_id, tenant_id: $tenant_id}),
+		      (u:User {id: $user_id})
+		MERGE (p)-[r:OWNED_BY]->(u)
+		ON CREATE SET r.created_at = datetime()
+	`
+	_, err = s.neo4j.ExecuteQueryWithLogging(ctx, userRelQuery, map[string]interface{}{
+		"production_id": production.ID,
+		"user_id":       production.UserID,
+		"tenant_id":     tenantID,
+	})
+	if err != nil {
+		s.logger.Warn("Failed to create OWNED_BY relationship", zap.Error(err))
+	}
+
+	// Create SOURCES relationships to Documents if specified
+	for _, docID := range production.SourceDocuments {
+		docRelQuery := `
+			MATCH (p:Production {id: $production_id, tenant_id: $tenant_id}),
+			      (d:Document {id: $document_id, tenant_id: $tenant_id})
+			MERGE (p)-[r:SOURCES]->(d)
+			ON CREATE SET r.created_at = datetime()
+		`
+		_, err = s.neo4j.ExecuteQueryWithLogging(ctx, docRelQuery, map[string]interface{}{
+			"production_id": production.ID,
+			"document_id":   docID,
+			"tenant_id":     tenantID,
+		})
+		if err != nil {
+			s.logger.Warn("Failed to create SOURCES relationship", zap.String("document_id", docID), zap.Error(err))
+		}
+	}
+
+	return nil
+}
+
+func (s *ProductionService) recordToProduction(record interface{}) (*models.Production, error) {
+	neo4jRecord, ok := record.(*neo4j.Record)
+	if !ok {
+		return nil, errors.Internal("Invalid record type")
+	}
+
+	production := &models.Production{}
+
+	// Extract fields
+	if id, found := neo4jRecord.Get("p.id"); found && id != nil {
+		production.ID = id.(string)
+	}
+	if title, found := neo4jRecord.Get("p.title"); found && title != nil {
+		production.Title = title.(string)
+	}
+	if pType, found := neo4jRecord.Get("p.type"); found && pType != nil {
+		production.Type = models.ProductionType(pType.(string))
+	}
+	if format, found := neo4jRecord.Get("p.format"); found && format != nil {
+		production.Format = models.ProductionFormat(format.(string))
+	}
+	if status, found := neo4jRecord.Get("p.status"); found && status != nil {
+		production.Status = models.ProductionStatus(status.(string))
+	}
+	if agentID, found := neo4jRecord.Get("p.agent_id"); found && agentID != nil {
+		production.AgentID = agentID.(string)
+	}
+	if agentBuilderID, found := neo4jRecord.Get("p.agent_builder_id"); found && agentBuilderID != nil {
+		production.AgentBuilderID = agentBuilderID.(string)
+	}
+	if notebookID, found := neo4jRecord.Get("p.notebook_id"); found && notebookID != nil {
+		production.NotebookID = notebookID.(string)
+	}
+	if userID, found := neo4jRecord.Get("p.user_id"); found && userID != nil {
+		production.UserID = userID.(string)
+	}
+	if spaceType, found := neo4jRecord.Get("p.space_type"); found && spaceType != nil {
+		production.SpaceType = models.SpaceType(spaceType.(string))
+	}
+	if spaceID, found := neo4jRecord.Get("p.space_id"); found && spaceID != nil {
+		production.SpaceID = spaceID.(string)
+	}
+	if tenantID, found := neo4jRecord.Get("p.tenant_id"); found && tenantID != nil {
+		production.TenantID = tenantID.(string)
+	}
+	if storageBucket, found := neo4jRecord.Get("p.storage_bucket"); found && storageBucket != nil {
+		production.StorageBucket = storageBucket.(string)
+	}
+	if storageKey, found := neo4jRecord.Get("p.storage_key"); found && storageKey != nil {
+		production.StorageKey = storageKey.(string)
+	}
+	if sizeBytes, found := neo4jRecord.Get("p.size_bytes"); found && sizeBytes != nil {
+		switch v := sizeBytes.(type) {
+		case int64:
+			production.SizeBytes = v
+		case float64:
+			production.SizeBytes = int64(v)
+		}
+	}
+	if executionID, found := neo4jRecord.Get("p.execution_id"); found && executionID != nil {
+		production.ExecutionID = executionID.(string)
+	}
+	if tokensUsed, found := neo4jRecord.Get("p.tokens_used"); found && tokensUsed != nil {
+		switch v := tokensUsed.(type) {
+		case int64:
+			production.TokensUsed = int(v)
+		case float64:
+			production.TokensUsed = int(v)
+		}
+	}
+	if costUSD, found := neo4jRecord.Get("p.cost_usd"); found && costUSD != nil {
+		switch v := costUSD.(type) {
+		case float64:
+			production.CostUSD = v
+		case int64:
+			production.CostUSD = float64(v)
+		}
+	}
+	if responseTimeMs, found := neo4jRecord.Get("p.response_time_ms"); found && responseTimeMs != nil {
+		switch v := responseTimeMs.(type) {
+		case int64:
+			production.ResponseTimeMs = int(v)
+		case float64:
+			production.ResponseTimeMs = int(v)
+		}
+	}
+	if errorMessage, found := neo4jRecord.Get("p.error_message"); found && errorMessage != nil {
+		production.ErrorMessage = errorMessage.(string)
+	}
+	if sourceDocuments, found := neo4jRecord.Get("p.source_documents"); found && sourceDocuments != nil {
+		if docs, ok := sourceDocuments.([]interface{}); ok {
+			for _, doc := range docs {
+				if docStr, ok := doc.(string); ok {
+					production.SourceDocuments = append(production.SourceDocuments, docStr)
+				}
+			}
+		}
+	}
+
+	// Parse timestamps
+	if createdAt, found := neo4jRecord.Get("p.created_at"); found && createdAt != nil {
+		if timeStr, ok := createdAt.(string); ok {
+			if parsed, err := time.Parse(time.RFC3339, timeStr); err == nil {
+				production.CreatedAt = parsed
+			}
+		} else if neo4jTime, ok := createdAt.(time.Time); ok {
+			production.CreatedAt = neo4jTime
+		}
+	}
+	if updatedAt, found := neo4jRecord.Get("p.updated_at"); found && updatedAt != nil {
+		if timeStr, ok := updatedAt.(string); ok {
+			if parsed, err := time.Parse(time.RFC3339, timeStr); err == nil {
+				production.UpdatedAt = parsed
+			}
+		} else if neo4jTime, ok := updatedAt.(time.Time); ok {
+			production.UpdatedAt = neo4jTime
+		}
+	}
+
+	return production, nil
+}
+
+func (s *ProductionService) recordToAgentResponse(record interface{}) (*models.AgentResponse, error) {
+	neo4jRecord, ok := record.(*neo4j.Record)
+	if !ok {
+		return nil, errors.Internal("Invalid record type")
+	}
+
+	agent := &models.AgentResponse{}
+
+	if id, found := neo4jRecord.Get("a.id"); found && id != nil {
+		agent.ID = id.(string)
+	}
+	if agentBuilderID, found := neo4jRecord.Get("a.agent_builder_id"); found && agentBuilderID != nil {
+		agent.AgentBuilderID = agentBuilderID.(string)
+	}
+	if name, found := neo4jRecord.Get("a.name"); found && name != nil {
+		agent.Name = name.(string)
+	}
+	if description, found := neo4jRecord.Get("a.description"); found && description != nil {
+		agent.Description = description.(string)
+	}
+	if status, found := neo4jRecord.Get("a.status"); found && status != nil {
+		agent.Status = models.AgentStatus(status.(string))
+	}
+	if agentType, found := neo4jRecord.Get("a.type"); found && agentType != nil {
+		agent.Type = models.AgentType(agentType.(string))
+	}
+	if ownerID, found := neo4jRecord.Get("a.owner_id"); found && ownerID != nil {
+		agent.OwnerID = ownerID.(string)
+	}
+	if spaceType, found := neo4jRecord.Get("a.space_type"); found && spaceType != nil {
+		agent.SpaceType = models.SpaceType(spaceType.(string))
+	}
+	if spaceID, found := neo4jRecord.Get("a.space_id"); found && spaceID != nil {
+		agent.SpaceID = spaceID.(string)
+	}
+	if teamID, found := neo4jRecord.Get("a.team_id"); found && teamID != nil {
+		agent.TeamID = teamID.(string)
+	}
+	if isPublic, found := neo4jRecord.Get("a.is_public"); found && isPublic != nil {
+		agent.IsPublic = isPublic.(bool)
+	}
+	if isTemplate, found := neo4jRecord.Get("a.is_template"); found && isTemplate != nil {
+		agent.IsTemplate = isTemplate.(bool)
+	}
+	if tags, found := neo4jRecord.Get("a.tags"); found && tags != nil {
+		if tagSlice, ok := tags.([]interface{}); ok {
+			for _, tag := range tagSlice {
+				if tagStr, ok := tag.(string); ok {
+					agent.Tags = append(agent.Tags, tagStr)
+				}
+			}
+		}
+	}
+
+	// Parse timestamps
+	if createdAt, found := neo4jRecord.Get("a.created_at"); found && createdAt != nil {
+		if timeStr, ok := createdAt.(string); ok {
+			if parsed, err := time.Parse(time.RFC3339, timeStr); err == nil {
+				agent.CreatedAt = parsed
+			}
+		} else if neo4jTime, ok := createdAt.(time.Time); ok {
+			agent.CreatedAt = neo4jTime
+		}
+	}
+	if updatedAt, found := neo4jRecord.Get("a.updated_at"); found && updatedAt != nil {
+		if timeStr, ok := updatedAt.(string); ok {
+			if parsed, err := time.Parse(time.RFC3339, timeStr); err == nil {
+				agent.UpdatedAt = parsed
+			}
+		} else if neo4jTime, ok := updatedAt.(time.Time); ok {
+			agent.UpdatedAt = neo4jTime
+		}
+	}
+
+	// Extract owner information
+	ownerUsername, hasOwnerUsername := neo4jRecord.Get("owner.username")
+	ownerFullName, hasOwnerFullName := neo4jRecord.Get("owner.full_name")
+	ownerAvatarURL, hasOwnerAvatarURL := neo4jRecord.Get("owner.avatar_url")
+
+	if hasOwnerUsername || hasOwnerFullName || hasOwnerAvatarURL {
+		agent.Owner = &models.PublicUserResponse{
+			ID: agent.OwnerID,
+		}
+		if hasOwnerUsername && ownerUsername != nil {
+			agent.Owner.Username = ownerUsername.(string)
+		}
+		if hasOwnerFullName && ownerFullName != nil {
+			agent.Owner.FullName = ownerFullName.(string)
+		}
+		if hasOwnerAvatarURL && ownerAvatarURL != nil {
+			agent.Owner.AvatarURL = ownerAvatarURL.(string)
+		}
+	}
+
+	return agent, nil
+}
+
+// Utility functions
+
+func getFileExtension(format models.ProductionFormat) string {
+	switch format {
+	case models.ProductionFormatMarkdown:
+		return "md"
+	case models.ProductionFormatHTML:
+		return "html"
+	case models.ProductionFormatJSON:
+		return "json"
+	case models.ProductionFormatText:
+		return "txt"
+	default:
+		return "txt"
+	}
+}
+
+func getContentType(format models.ProductionFormat) string {
+	switch format {
+	case models.ProductionFormatMarkdown:
+		return "text/markdown"
+	case models.ProductionFormatHTML:
+		return "text/html"
+	case models.ProductionFormatJSON:
+		return "application/json"
+	case models.ProductionFormatText:
+		return "text/plain"
+	default:
+		return "text/plain"
+	}
+}
+
+// NotebookChatResponse represents a response from notebook chat
+type NotebookChatResponse struct {
+	Content string `json:"content"`
+}
+
+// NotebookChatAssistantID is the ID of the internal notebook chat agent
+const NotebookChatAssistantID = "00000000-0000-0000-0000-000000000009"
+
+// ExecuteNotebookChat executes the internal Notebook Chat Assistant agent for a notebook
+// This uses agent-builder to retrieve document context and inject it into the prompt
+func (s *ProductionService) ExecuteNotebookChat(
+	ctx context.Context,
+	notebookID string,
+	message string,
+	history []models.ConversationMessage,
+	userID string,
+	authToken string,
+	spaceCtx *models.SpaceContext,
+) (*NotebookChatResponse, error) {
+	// Verify notebook exists and user has access
+	notebook, err := s.notebookService.GetNotebookByID(ctx, notebookID, userID, spaceCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve Aether tenant ID to AudiModal UUID
+	// This is needed for agent-builder to fetch document chunks from AudiModal
+	var audimodalTenantID string
+	if s.audiModal != nil {
+		resolvedUUID, err := s.audiModal.GetAudiModalTenantUUID(ctx, notebook.TenantID)
+		if err != nil {
+			s.logger.Warn("Failed to resolve AudiModal tenant UUID for notebook chat",
+				zap.String("notebook_tenant_id", notebook.TenantID),
+				zap.Error(err))
+			audimodalTenantID = extractTenantSuffix(notebook.TenantID)
+		} else {
+			audimodalTenantID = resolvedUUID
+			s.logger.Debug("Resolved AudiModal tenant UUID for notebook chat",
+				zap.String("notebook_tenant_id", notebook.TenantID),
+				zap.String("audimodal_tenant_uuid", audimodalTenantID))
+		}
+	} else {
+		audimodalTenantID = extractTenantSuffix(notebook.TenantID)
+		s.logger.Warn("AudiModalService not available for notebook chat",
+			zap.String("audimodal_tenant_id", audimodalTenantID))
+	}
+
+	// Get AudiModal file IDs for all documents in the notebook
+	// Agent-builder needs these to fetch document chunks for context injection
+	audimodalFileIDs, _ := s.getNotebookAudiModalFileIDs(ctx, notebook.ID, notebook.TenantID)
+
+	s.logger.Debug("Retrieved AudiModal file IDs for notebook chat",
+		zap.String("notebook_id", notebook.ID),
+		zap.Int("file_id_count", len(audimodalFileIDs)),
+		zap.Strings("file_ids", audimodalFileIDs))
+
+	// Convert conversation history to services.ConversationMessage
+	var serviceHistory []ConversationMessage
+	for _, msg := range history {
+		serviceHistory = append(serviceHistory, ConversationMessage{
+			Role:      msg.Role,
+			Content:   msg.Content,
+			Timestamp: msg.Timestamp.Format("2006-01-02T15:04:05Z07:00"),
+		})
+	}
+
+	// Build the execution request for agent-builder
+	// This passes notebook IDs and file IDs so agent-builder can retrieve document context
+	executeReq := InternalAgentExecuteRequest{
+		Input:       message,
+		NotebookIDs: []string{notebook.ID},
+		TenantID:    audimodalTenantID,
+		History:     serviceHistory,
+	}
+
+	// Add AudiModal file IDs so agent-builder can fetch document chunks
+	if len(audimodalFileIDs) > 0 {
+		executeReq.SelectedDocuments = audimodalFileIDs
+	}
+
+	s.logger.Info("Executing notebook chat via agent-builder",
+		zap.String("notebook_id", notebook.ID),
+		zap.String("audimodal_tenant_id", audimodalTenantID),
+		zap.Int("history_length", len(history)),
+		zap.Int("file_ids", len(audimodalFileIDs)),
+		zap.String("user_id", userID),
+	)
+
+	// Execute via agent-builder which will:
+	// 1. Retrieve document context from AudiModal based on file IDs
+	// 2. Inject the context into the system prompt
+	// 3. Call the LLM with the enriched prompt and conversation history
+	response, err := s.agentService.ExecuteInternalAgent(ctx, NotebookChatAssistantID, executeReq, authToken)
+	if err != nil {
+		s.logger.Error("Failed to execute notebook chat via agent-builder",
+			zap.String("notebook_id", notebookID),
+			zap.Error(err))
+		return nil, errors.Internal("Failed to execute chat request")
+	}
+
+	s.logger.Info("Notebook chat executed successfully via agent-builder",
+		zap.String("notebook_id", notebookID),
+		zap.String("user_id", userID),
+		zap.String("execution_id", response.ExecutionID),
+		zap.Int("output_length", len(response.Output)),
+	)
+
+	return &NotebookChatResponse{
+		Content: response.Output,
+	}, nil
+}

--- a/internal/validation/sanitizer.go
+++ b/internal/validation/sanitizer.go
@@ -347,3 +347,252 @@ func SanitizeURL(url string) string {
 
 	return SanitizeString(url, options)
 }
+
+// ============================================================================
+// Web Content Sanitization (for Crawl4AI and web scraping)
+// ============================================================================
+
+var (
+	// Script block removal (including content)
+	scriptBlockRegex = regexp.MustCompile(`(?is)<script[^>]*>.*?</script>`)
+
+	// Style block removal (including content)
+	styleBlockRegex = regexp.MustCompile(`(?is)<style[^>]*>.*?</style>`)
+
+	// Noscript block removal
+	noscriptBlockRegex = regexp.MustCompile(`(?is)<noscript[^>]*>.*?</noscript>`)
+
+	// Event handlers (onclick, onerror, onload, onmouseover, onfocus, etc.)
+	eventHandlerRegex = regexp.MustCompile(`(?i)\s+on\w+\s*=\s*["'][^"']*["']`)
+	eventHandlerUnquotedRegex = regexp.MustCompile(`(?i)\s+on\w+\s*=\s*[^\s>]+`)
+
+	// JavaScript URLs
+	jsURLRegex = regexp.MustCompile(`(?i)javascript\s*:`)
+
+	// VBScript URLs
+	vbURLRegex = regexp.MustCompile(`(?i)vbscript\s*:`)
+
+	// Data URLs (can be used for XSS)
+	dataURLXSSRegex = regexp.MustCompile(`(?i)data\s*:\s*text/html`)
+
+	// Dangerous tags (complete removal including content for some)
+	iframeRegex  = regexp.MustCompile(`(?is)<iframe[^>]*>.*?</iframe>|<iframe[^>]*/>|<iframe[^>]*>`)
+	objectRegex  = regexp.MustCompile(`(?is)<object[^>]*>.*?</object>|<object[^>]*/>|<object[^>]*>`)
+	embedRegex   = regexp.MustCompile(`(?i)<embed[^>]*>`)  // embed is typically self-closing
+	appletRegex  = regexp.MustCompile(`(?is)<applet[^>]*>.*?</applet>`)
+	formRegex    = regexp.MustCompile(`(?is)<form[^>]*>.*?</form>`)
+	inputRegex   = regexp.MustCompile(`(?i)<input[^>]*>`)
+	buttonRegex  = regexp.MustCompile(`(?is)<button[^>]*>.*?</button>|<button[^>]*/>|<button[^>]*>`)
+	svgScriptRegex = regexp.MustCompile(`(?is)<svg[^>]*>.*?</svg>`)
+
+	// Base tag (can redirect resources)
+	baseTagRegex = regexp.MustCompile(`(?i)<base[^>]*>`)
+
+	// Meta refresh (can redirect)
+	metaRefreshRegex = regexp.MustCompile(`(?i)<meta[^>]*http-equiv\s*=\s*["']?refresh["']?[^>]*>`)
+
+	// Link tags with javascript
+	linkJSRegex = regexp.MustCompile(`(?i)<link[^>]*href\s*=\s*["']?javascript:[^>]*>`)
+)
+
+// WebContentSanitizationOptions controls how web content is sanitized
+type WebContentSanitizationOptions struct {
+	// RemoveScripts removes <script> tags and their content
+	RemoveScripts bool
+
+	// RemoveStyles removes <style> tags and their content
+	RemoveStyles bool
+
+	// RemoveEventHandlers removes onclick, onerror, onload, etc.
+	RemoveEventHandlers bool
+
+	// RemoveJavaScriptURLs removes javascript: URLs
+	RemoveJavaScriptURLs bool
+
+	// RemoveDangerousTags removes iframe, object, embed, applet, form, etc.
+	RemoveDangerousTags bool
+
+	// RemoveBaseTag removes <base> tags that can redirect resources
+	RemoveBaseTag bool
+
+	// RemoveMetaRefresh removes meta refresh redirects
+	RemoveMetaRefresh bool
+
+	// PreserveMarkdown keeps markdown formatting intact (don't strip as HTML)
+	PreserveMarkdown bool
+
+	// MaxContentLength limits content size (0 = no limit)
+	MaxContentLength int
+}
+
+// DefaultWebContentSanitizationOptions returns sensible defaults for web scraping
+func DefaultWebContentSanitizationOptions() WebContentSanitizationOptions {
+	return WebContentSanitizationOptions{
+		RemoveScripts:        true,
+		RemoveStyles:         true,
+		RemoveEventHandlers:  true,
+		RemoveJavaScriptURLs: true,
+		RemoveDangerousTags:  true,
+		RemoveBaseTag:        true,
+		RemoveMetaRefresh:    true,
+		PreserveMarkdown:     false,
+		MaxContentLength:     0, // No limit by default
+	}
+}
+
+// StrictWebContentSanitizationOptions returns strict options for high-security contexts
+func StrictWebContentSanitizationOptions() WebContentSanitizationOptions {
+	return WebContentSanitizationOptions{
+		RemoveScripts:        true,
+		RemoveStyles:         true,
+		RemoveEventHandlers:  true,
+		RemoveJavaScriptURLs: true,
+		RemoveDangerousTags:  true,
+		RemoveBaseTag:        true,
+		RemoveMetaRefresh:    true,
+		PreserveMarkdown:     false,
+		MaxContentLength:     10 * 1024 * 1024, // 10MB limit
+	}
+}
+
+// SanitizeWebContent sanitizes HTML/web content from crawlers to prevent XSS
+// This is designed for large web content and preserves text structure while
+// removing potentially dangerous elements
+func SanitizeWebContent(content string, options WebContentSanitizationOptions) string {
+	if content == "" {
+		return content
+	}
+
+	result := content
+
+	// Remove script blocks (including content) - most critical
+	if options.RemoveScripts {
+		result = scriptBlockRegex.ReplaceAllString(result, "")
+		result = noscriptBlockRegex.ReplaceAllString(result, "")
+	}
+
+	// Remove style blocks
+	if options.RemoveStyles {
+		result = styleBlockRegex.ReplaceAllString(result, "")
+	}
+
+	// Remove dangerous tags
+	if options.RemoveDangerousTags {
+		result = iframeRegex.ReplaceAllString(result, "")
+		result = objectRegex.ReplaceAllString(result, "")
+		result = embedRegex.ReplaceAllString(result, "")
+		result = appletRegex.ReplaceAllString(result, "")
+		result = formRegex.ReplaceAllString(result, "")
+		result = inputRegex.ReplaceAllString(result, "")
+		result = buttonRegex.ReplaceAllString(result, "")
+		result = svgScriptRegex.ReplaceAllString(result, "")
+	}
+
+	// Remove event handlers from remaining tags
+	if options.RemoveEventHandlers {
+		result = eventHandlerRegex.ReplaceAllString(result, "")
+		result = eventHandlerUnquotedRegex.ReplaceAllString(result, "")
+	}
+
+	// Remove JavaScript URLs
+	if options.RemoveJavaScriptURLs {
+		result = jsURLRegex.ReplaceAllString(result, "")
+		result = vbURLRegex.ReplaceAllString(result, "")
+		result = dataURLXSSRegex.ReplaceAllString(result, "data:")
+	}
+
+	// Remove base tag
+	if options.RemoveBaseTag {
+		result = baseTagRegex.ReplaceAllString(result, "")
+	}
+
+	// Remove meta refresh
+	if options.RemoveMetaRefresh {
+		result = metaRefreshRegex.ReplaceAllString(result, "")
+	}
+
+	// Remove link tags with javascript hrefs
+	result = linkJSRegex.ReplaceAllString(result, "")
+
+	// Enforce max length if specified
+	if options.MaxContentLength > 0 && len(result) > options.MaxContentLength {
+		result = result[:options.MaxContentLength]
+	}
+
+	return result
+}
+
+// SanitizeMarkdownContent sanitizes markdown content while preserving formatting
+// This is less aggressive than HTML sanitization since markdown is text-based
+func SanitizeMarkdownContent(content string, options WebContentSanitizationOptions) string {
+	if content == "" {
+		return content
+	}
+
+	result := content
+
+	// Remove any embedded HTML script tags (sometimes markdown allows raw HTML)
+	result = scriptBlockRegex.ReplaceAllString(result, "")
+	result = styleBlockRegex.ReplaceAllString(result, "")
+
+	// Remove event handlers if any raw HTML is present
+	if options.RemoveEventHandlers {
+		result = eventHandlerRegex.ReplaceAllString(result, "")
+		result = eventHandlerUnquotedRegex.ReplaceAllString(result, "")
+	}
+
+	// Remove JavaScript URLs from links
+	if options.RemoveJavaScriptURLs {
+		result = jsURLRegex.ReplaceAllString(result, "")
+		result = vbURLRegex.ReplaceAllString(result, "")
+	}
+
+	// Remove dangerous raw HTML tags
+	if options.RemoveDangerousTags {
+		result = iframeRegex.ReplaceAllString(result, "")
+		result = objectRegex.ReplaceAllString(result, "")
+		result = embedRegex.ReplaceAllString(result, "")
+	}
+
+	// Control characters (but preserve newlines for markdown formatting)
+	result = regexp.MustCompile(`[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]`).ReplaceAllString(result, "")
+
+	// Enforce max length if specified
+	if options.MaxContentLength > 0 && len(result) > options.MaxContentLength {
+		result = result[:options.MaxContentLength]
+	}
+
+	return result
+}
+
+// SanitizeMediaURL sanitizes URLs for media resources (images, videos, etc.)
+func SanitizeMediaURL(url string) string {
+	if url == "" {
+		return url
+	}
+
+	// Check for dangerous protocols
+	lowercaseURL := strings.ToLower(strings.TrimSpace(url))
+	if strings.HasPrefix(lowercaseURL, "javascript:") ||
+		strings.HasPrefix(lowercaseURL, "vbscript:") ||
+		strings.HasPrefix(lowercaseURL, "data:text/html") {
+		return "" // Block dangerous protocols
+	}
+
+	// Allow data: URLs for images (base64 encoded images are common and safe)
+	// but block data:text/html which can execute scripts
+	if strings.HasPrefix(lowercaseURL, "data:") {
+		if strings.HasPrefix(lowercaseURL, "data:image/") {
+			return url // Allow image data URLs
+		}
+		return "" // Block other data URLs
+	}
+
+	// Remove control characters
+	result := controlCharsRegex.ReplaceAllString(url, "")
+
+	// Trim whitespace
+	result = strings.TrimSpace(result)
+
+	return result
+}

--- a/internal/validation/sanitizer_test.go
+++ b/internal/validation/sanitizer_test.go
@@ -275,3 +275,248 @@ func TestSanitizationOptions(t *testing.T) {
 		assert.False(t, options.CollapseWhitespace)
 	})
 }
+
+// ============================================================================
+// Web Content Sanitization Tests (for Crawl4AI and web scraping)
+// ============================================================================
+
+func TestSanitizeWebContent(t *testing.T) {
+	options := DefaultWebContentSanitizationOptions()
+
+	t.Run("removes script tags with content", func(t *testing.T) {
+		input := `<html><body>
+			<h1>Hello World</h1>
+			<script>alert('xss')</script>
+			<script type="text/javascript">
+				var x = 1;
+				document.write("malicious");
+			</script>
+			<p>Safe content</p>
+		</body></html>`
+
+		result := SanitizeWebContent(input, options)
+		assert.NotContains(t, result, "<script>")
+		assert.NotContains(t, result, "</script>")
+		assert.NotContains(t, result, "alert('xss')")
+		assert.NotContains(t, result, "document.write")
+		assert.Contains(t, result, "<h1>Hello World</h1>")
+		assert.Contains(t, result, "<p>Safe content</p>")
+	})
+
+	t.Run("removes style tags with content", func(t *testing.T) {
+		input := `<html><body>
+			<style>body { background: red; }</style>
+			<p>Content</p>
+		</body></html>`
+
+		result := SanitizeWebContent(input, options)
+		assert.NotContains(t, result, "<style>")
+		assert.NotContains(t, result, "</style>")
+		assert.NotContains(t, result, "background: red")
+		assert.Contains(t, result, "<p>Content</p>")
+	})
+
+	t.Run("removes event handlers", func(t *testing.T) {
+		input := `<div onclick="alert('xss')" onmouseover="steal()" onerror="hack()">Content</div>
+			<img src="x.jpg" onerror="alert('img xss')" alt="image">
+			<a href="#" onload="malicious()">Link</a>`
+
+		result := SanitizeWebContent(input, options)
+		assert.NotContains(t, result, "onclick=")
+		assert.NotContains(t, result, "onmouseover=")
+		assert.NotContains(t, result, "onerror=")
+		assert.NotContains(t, result, "onload=")
+		assert.NotContains(t, result, "alert(")
+		assert.Contains(t, result, "Content")
+		assert.Contains(t, result, "Link")
+	})
+
+	t.Run("removes javascript: URLs", func(t *testing.T) {
+		input := `<a href="javascript:alert('xss')">Click me</a>
+			<a href="JAVASCRIPT:void(0)">Another link</a>`
+
+		result := SanitizeWebContent(input, options)
+		assert.NotContains(t, result, "javascript:")
+		assert.NotContains(t, result, "JAVASCRIPT:")
+		assert.Contains(t, result, "Click me")
+	})
+
+	t.Run("removes iframe tags", func(t *testing.T) {
+		input := `<p>Safe</p>
+			<iframe src="http://evil.com" width="100%" height="100%"></iframe>
+			<p>Also safe</p>`
+
+		result := SanitizeWebContent(input, options)
+		assert.NotContains(t, result, "<iframe")
+		assert.NotContains(t, result, "</iframe>")
+		assert.NotContains(t, result, "evil.com")
+		assert.Contains(t, result, "<p>Safe</p>")
+		assert.Contains(t, result, "<p>Also safe</p>")
+	})
+
+	t.Run("removes object and embed tags", func(t *testing.T) {
+		input := `<object data="malicious.swf"></object>
+			<embed src="bad.swf" type="application/x-shockwave-flash">`
+
+		result := SanitizeWebContent(input, options)
+		assert.NotContains(t, result, "<object")
+		assert.NotContains(t, result, "<embed")
+	})
+
+	t.Run("removes form elements", func(t *testing.T) {
+		input := `<form action="http://evil.com/steal">
+			<input type="text" name="password">
+			<button type="submit">Submit</button>
+		</form>`
+
+		result := SanitizeWebContent(input, options)
+		assert.NotContains(t, result, "<form")
+		assert.NotContains(t, result, "<input")
+		assert.NotContains(t, result, "<button")
+	})
+
+	t.Run("removes base tag", func(t *testing.T) {
+		input := `<head><base href="http://evil.com/"></head><body><p>Content</p></body>`
+
+		result := SanitizeWebContent(input, options)
+		assert.NotContains(t, result, "<base")
+	})
+
+	t.Run("removes meta refresh", func(t *testing.T) {
+		input := `<head><meta http-equiv="refresh" content="0;url=http://evil.com"></head><body><p>Content</p></body>`
+
+		result := SanitizeWebContent(input, options)
+		assert.NotContains(t, result, "http-equiv")
+		assert.NotContains(t, result, "refresh")
+	})
+
+	t.Run("handles empty input", func(t *testing.T) {
+		result := SanitizeWebContent("", options)
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("preserves safe HTML structure", func(t *testing.T) {
+		input := `<html>
+			<head><title>Safe Page</title></head>
+			<body>
+				<h1>Welcome</h1>
+				<p>This is <strong>safe</strong> content.</p>
+				<ul>
+					<li>Item 1</li>
+					<li>Item 2</li>
+				</ul>
+				<a href="https://example.com">Safe link</a>
+				<img src="https://example.com/image.jpg" alt="Safe image">
+			</body>
+		</html>`
+
+		result := SanitizeWebContent(input, options)
+		assert.Contains(t, result, "<h1>Welcome</h1>")
+		assert.Contains(t, result, "<strong>safe</strong>")
+		assert.Contains(t, result, "<li>Item 1</li>")
+		assert.Contains(t, result, `href="https://example.com"`)
+		assert.Contains(t, result, `src="https://example.com/image.jpg"`)
+	})
+
+	t.Run("enforces max length when specified", func(t *testing.T) {
+		options := DefaultWebContentSanitizationOptions()
+		options.MaxContentLength = 100
+		input := strings.Repeat("a", 200)
+
+		result := SanitizeWebContent(input, options)
+		assert.Equal(t, 100, len(result))
+	})
+}
+
+func TestSanitizeMarkdownContent(t *testing.T) {
+	options := DefaultWebContentSanitizationOptions()
+
+	t.Run("removes embedded script tags", func(t *testing.T) {
+		input := `# Heading
+
+This is safe markdown.
+
+<script>alert('xss')</script>
+
+More safe content.`
+
+		result := SanitizeMarkdownContent(input, options)
+		assert.NotContains(t, result, "<script>")
+		assert.NotContains(t, result, "alert('xss')")
+		assert.Contains(t, result, "# Heading")
+		assert.Contains(t, result, "This is safe markdown.")
+		assert.Contains(t, result, "More safe content.")
+	})
+
+	t.Run("removes javascript URLs from markdown links", func(t *testing.T) {
+		input := `[Click here](javascript:alert('xss'))
+[Safe link](https://example.com)`
+
+		result := SanitizeMarkdownContent(input, options)
+		assert.NotContains(t, result, "javascript:")
+		assert.Contains(t, result, "[Safe link](https://example.com)")
+	})
+
+	t.Run("preserves markdown formatting", func(t *testing.T) {
+		input := "# Heading 1\n\n## Heading 2\n\n- List item 1\n- List item 2\n\n**Bold** and *italic* text.\n\n```go\nfunc main() {\n    fmt.Println(\"Hello\")\n}\n```\n"
+
+		result := SanitizeMarkdownContent(input, options)
+		assert.Contains(t, result, "# Heading 1")
+		assert.Contains(t, result, "## Heading 2")
+		assert.Contains(t, result, "- List item 1")
+		assert.Contains(t, result, "**Bold**")
+		assert.Contains(t, result, "*italic*")
+		assert.Contains(t, result, "```go")
+	})
+
+	t.Run("handles empty input", func(t *testing.T) {
+		result := SanitizeMarkdownContent("", options)
+		assert.Equal(t, "", result)
+	})
+}
+
+func TestSanitizeMediaURL(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"valid https URL", "https://example.com/image.jpg", "https://example.com/image.jpg"},
+		{"valid http URL", "http://example.com/video.mp4", "http://example.com/video.mp4"},
+		{"data URL for image", "data:image/png;base64,abc123", "data:image/png;base64,abc123"},
+		{"javascript URL", "javascript:alert('xss')", ""},
+		{"vbscript URL", "vbscript:msgbox('xss')", ""},
+		{"data URL with text/html", "data:text/html,<script>alert('xss')</script>", ""},
+		{"empty string", "", ""},
+		{"URL with control chars", "https://example.com/image\x00.jpg", "https://example.com/image.jpg"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := SanitizeMediaURL(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestWebContentSanitizationOptions(t *testing.T) {
+	t.Run("default options", func(t *testing.T) {
+		options := DefaultWebContentSanitizationOptions()
+		assert.True(t, options.RemoveScripts)
+		assert.True(t, options.RemoveStyles)
+		assert.True(t, options.RemoveEventHandlers)
+		assert.True(t, options.RemoveJavaScriptURLs)
+		assert.True(t, options.RemoveDangerousTags)
+		assert.True(t, options.RemoveBaseTag)
+		assert.True(t, options.RemoveMetaRefresh)
+		assert.False(t, options.PreserveMarkdown)
+		assert.Equal(t, 0, options.MaxContentLength)
+	})
+
+	t.Run("strict options", func(t *testing.T) {
+		options := StrictWebContentSanitizationOptions()
+		assert.True(t, options.RemoveScripts)
+		assert.True(t, options.RemoveDangerousTags)
+		assert.Equal(t, 10*1024*1024, options.MaxContentLength)
+	})
+}


### PR DESCRIPTION
## Summary

- Add production handler for producer agent executions (Q&A, Summary, Outline, Insights)
- Fix notebook chat to use document context via agent-builder instead of bypassing it
- Add XSS sanitization for crawl4ai web scraping
- Clean up legacy hardcoded prompts from internal_agents.go

## Key Changes

### Notebook Chat Fix
- `ExecuteNotebookChat` now uses agent-builder to retrieve and inject document context
- Previously it bypassed agent-builder and called LLM directly without document content
- Chat now properly answers questions about notebook documents

### Production Handler
- New `/notebooks/:id/producers/:agent_id/execute` endpoint for producer agents
- New `/notebooks/:id/chat` endpoint for notebook chat
- Integrates with agent-builder for document context retrieval

### Code Cleanup
- Removed 680+ lines of legacy hardcoded prompts from internal_agents.go
- Agents now come from agent-builder database
- Created GitHub issue #15 to track moving remaining prompts to DB

## Test plan

- [x] Tested notebook chat with document queries - now returns document-based answers
- [x] Tested producer agents (Summary, Q&A, Outline, Insights) - all working
- [x] Verified build compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)