### PR TITLE
Add podcast renderer workflow system

### DIFF
--- a/internal/handlers/production.go
+++ b/internal/handlers/production.go
@@ -832,6 +832,28 @@ func (h *ProductionHandler) BulkDeleteProductions(c *gin.Context) {
 	})
 }
 
+// ListRenderers returns available renderer workflows
+// @Summary List renderers
+// @Description Get available renderer workflows for post-processing productions
+// @Tags productions
+// @Produce json
+// @Security Bearer
+// @Success 200 {array} map[string]interface{}
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/renderers [get]
+func (h *ProductionHandler) ListRenderers(c *gin.Context) {
+	renderers, err := h.productionService.ListRenderers(c.Request.Context())
+	if err != nil {
+		h.logger.Error("Failed to list renderers", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, errors.Internal("Failed to list renderers"))
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"renderers": renderers,
+	})
+}
+
 // getUserTeams retrieves team IDs for a user for access control purposes
 func (h *ProductionHandler) getUserTeams(c *gin.Context, userID string) ([]string, error) {
 	teamIDs, err := h.teamService.GetUserTeamIDs(c.Request.Context(), userID)

--- a/internal/handlers/routes.go
+++ b/internal/handlers/routes.go
@@ -169,8 +169,9 @@ func NewAPIServer(
 	aiPlaygroundService := services.NewAIPlaygroundService(neo4j, &cfg.Router, agentService, workflowService, log)
 	aiPlaygroundHandler := NewAIPlaygroundHandler(aiPlaygroundService, userService, teamService, log)
 
-	// Initialize Production service and handler
-	productionService := services.NewProductionService(neo4j, storageService, agentService, notebookService, teamService, spaceService, audiModalClient, log)
+	// Initialize Podcast MCP client and Production service
+	podcastMCPClient := services.NewMCPClientService("podcast-mcp", &cfg.PodcastMCP, log)
+	productionService := services.NewProductionService(neo4j, storageService, agentService, notebookService, teamService, spaceService, audiModalClient, podcastMCPClient, log)
 	productionHandler := NewProductionHandler(productionService, userService, teamService, log)
 
 	// Initialize Argo Events service and handler
@@ -209,7 +210,7 @@ func NewAPIServer(
 
 	// Initialize Napkin MCP service and MCP handler
 	napkinService := services.NewNapkinService(&cfg.Napkin, log)
-	mcpHandler := NewMCPHandler(napkinService, cfg, log)
+	mcpHandler := NewMCPHandler(napkinService, databaseService, neo4jQueryService, cfg, log)
 
 	// Initialize router handler (may be nil if disabled)
 	routerHandler, err := NewRouterHandler(&cfg.Router, log)
@@ -378,6 +379,9 @@ func (s *APIServer) setupRoutes(keycloakClient *auth.KeycloakClient) {
 		productions.DELETE("/:id", s.ProductionHandler.DeleteProduction)
 		productions.POST("/bulk-delete", s.ProductionHandler.BulkDeleteProductions)
 	}
+
+	// Renderer routes - list available renderer workflows
+	api.GET("/renderers", s.ProductionHandler.ListRenderers)
 
 	// Chunk routes - file-specific chunks
 	files := api.Group("/files")

--- a/internal/models/production.go
+++ b/internal/models/production.go
@@ -24,6 +24,7 @@ const (
 	ProductionTypeOutline ProductionType = "outline"
 	ProductionTypeInsight ProductionType = "insight"
 	ProductionTypeCustom  ProductionType = "custom"
+	ProductionTypePodcast ProductionType = "podcast"
 )
 
 // ProductionFormat represents the output format of a production
@@ -34,6 +35,7 @@ const (
 	ProductionFormatHTML     ProductionFormat = "html"
 	ProductionFormatJSON     ProductionFormat = "json"
 	ProductionFormatText     ProductionFormat = "text"
+	ProductionFormatAudio    ProductionFormat = "audio"
 )
 
 // Production represents a generated artifact from a producer agent
@@ -43,8 +45,8 @@ type Production struct {
 	Title string `json:"title" validate:"required,min=1,max=255"`
 
 	// Production type and format
-	Type   ProductionType   `json:"type" validate:"required,oneof=summary qa outline insight custom"`
-	Format ProductionFormat `json:"format" validate:"required,oneof=markdown html json text"`
+	Type   ProductionType   `json:"type" validate:"required,oneof=summary qa outline insight custom podcast"`
+	Format ProductionFormat `json:"format" validate:"required,oneof=markdown html json text audio"`
 	Status ProductionStatus `json:"status" validate:"required,oneof=processing completed failed"`
 
 	// Agent that created this production
@@ -71,6 +73,11 @@ type Production struct {
 	CostUSD        float64 `json:"cost_usd"`
 	ResponseTimeMs int     `json:"response_time_ms"`
 
+	// Renderer (post-processing)
+	MediaURL      string                 `json:"media_url,omitempty"`
+	MediaMetadata map[string]interface{} `json:"media_metadata,omitempty"`
+	RendererID    string                 `json:"renderer_id,omitempty"`
+
 	// Error handling
 	ErrorMessage string `json:"error_message,omitempty"`
 
@@ -88,8 +95,8 @@ type Production struct {
 // ProductionCreateRequest represents a request to create/execute a production
 type ProductionCreateRequest struct {
 	Title           string           `json:"title" validate:"required,safe_string,min=1,max=255"`
-	Type            ProductionType   `json:"type" validate:"required,oneof=summary qa outline insight custom"`
-	Format          ProductionFormat `json:"format" validate:"required,oneof=markdown html json text"`
+	Type            ProductionType   `json:"type" validate:"required,oneof=summary qa outline insight custom podcast"`
+	Format          ProductionFormat `json:"format" validate:"required,oneof=markdown html json text audio"`
 	SourceDocuments []string         `json:"source_documents,omitempty" validate:"dive,uuid"`
 
 	// Optional context/parameters for the producer agent
@@ -120,10 +127,13 @@ type ProductionResponse struct {
 	TokensUsed      int              `json:"tokensUsed"`
 	CostUSD         float64          `json:"costUsd"`
 	ResponseTimeMs  int              `json:"responseTimeMs"`
-	ErrorMessage    string           `json:"errorMessage,omitempty"`
-	SourceDocuments []string         `json:"sourceDocuments,omitempty"`
-	CreatedAt       time.Time        `json:"createdAt"`
-	UpdatedAt       time.Time        `json:"updatedAt"`
+	ErrorMessage    string                 `json:"errorMessage,omitempty"`
+	MediaURL        string                 `json:"mediaUrl,omitempty"`
+	MediaMetadata   map[string]interface{} `json:"mediaMetadata,omitempty"`
+	RendererID      string                 `json:"rendererId,omitempty"`
+	SourceDocuments []string               `json:"sourceDocuments,omitempty"`
+	CreatedAt       time.Time              `json:"createdAt"`
+	UpdatedAt       time.Time              `json:"updatedAt"`
 
 	// Optional related data
 	Agent    *AgentResponse    `json:"agent,omitempty"`
@@ -148,7 +158,7 @@ type ProductionSearchRequest struct {
 	Query      string           `json:"query,omitempty" validate:"omitempty,safe_string,min=2,max=100"`
 	NotebookID string           `json:"notebook_id,omitempty" validate:"omitempty,uuid"`
 	AgentID    string           `json:"agent_id,omitempty" validate:"omitempty,uuid"`
-	Type       ProductionType   `json:"type,omitempty" validate:"omitempty,oneof=summary qa outline insight custom"`
+	Type       ProductionType   `json:"type,omitempty" validate:"omitempty,oneof=summary qa outline insight custom podcast"`
 	Status     ProductionStatus `json:"status,omitempty" validate:"omitempty,oneof=processing completed failed"`
 	Limit      int              `json:"limit,omitempty" validate:"omitempty,min=1,max=100"`
 	Offset     int              `json:"offset,omitempty" validate:"omitempty,min=0"`
@@ -158,8 +168,8 @@ type ProductionSearchRequest struct {
 type ProducerExecuteRequest struct {
 	AgentID         string           `json:"agent_id" validate:"required,uuid"`
 	Title           string           `json:"title" validate:"required,safe_string,min=1,max=255"`
-	Type            ProductionType   `json:"type" validate:"required,oneof=summary qa outline insight custom"`
-	Format          ProductionFormat `json:"format" validate:"required,oneof=markdown html json text"`
+	Type            ProductionType   `json:"type" validate:"required,oneof=summary qa outline insight custom podcast"`
+	Format          ProductionFormat `json:"format" validate:"required,oneof=markdown html json text audio"`
 	SourceDocuments []string         `json:"source_documents,omitempty" validate:"dive,uuid"`
 	Context         map[string]interface{} `json:"context,omitempty"`
 }
@@ -218,8 +228,8 @@ type UpdateProducerPreferencesRequest struct {
 	NotebookID string `json:"notebook_id,omitempty"`
 
 	// Settings updates
-	DefaultFormat *ProductionFormat `json:"default_format,omitempty" validate:"omitempty,oneof=markdown html json text"`
-	DefaultType   *ProductionType   `json:"default_type,omitempty" validate:"omitempty,oneof=summary qa outline insight custom"`
+	DefaultFormat *ProductionFormat `json:"default_format,omitempty" validate:"omitempty,oneof=markdown html json text audio"`
+	DefaultType   *ProductionType   `json:"default_type,omitempty" validate:"omitempty,oneof=summary qa outline insight custom podcast"`
 }
 
 // NewProduction creates a new production with default values
@@ -265,6 +275,9 @@ func (p *Production) ToResponse() *ProductionResponse {
 		CostUSD:         p.CostUSD,
 		ResponseTimeMs:  p.ResponseTimeMs,
 		ErrorMessage:    p.ErrorMessage,
+		MediaURL:        p.MediaURL,
+		MediaMetadata:   p.MediaMetadata,
+		RendererID:      p.RendererID,
 		SourceDocuments: p.SourceDocuments,
 		CreatedAt:       p.CreatedAt,
 		UpdatedAt:       p.UpdatedAt,

--- a/internal/models/workflow.go
+++ b/internal/models/workflow.go
@@ -156,7 +156,7 @@ type WorkflowVersion struct {
 type CreateWorkflowRequest struct {
 	Name          string                 `json:"name" binding:"required"`
 	Description   string                 `json:"description"`
-	Type          string                 `json:"type" binding:"required,oneof=document_processing compliance_check approval_chain data_pipeline ai_research media custom"`
+	Type          string                 `json:"type" binding:"required,oneof=document_processing compliance_check approval_chain data_pipeline ai_research media renderer custom"`
 	Configuration map[string]interface{} `json:"configuration"`
 	Steps         []CreateStepRequest    `json:"steps" binding:"required,min=1"`
 	Triggers      []CreateTriggerRequest `json:"triggers" binding:"required,min=1"`

--- a/internal/models/workflow.go
+++ b/internal/models/workflow.go
@@ -156,7 +156,7 @@ type WorkflowVersion struct {
 type CreateWorkflowRequest struct {
 	Name          string                 `json:"name" binding:"required"`
 	Description   string                 `json:"description"`
-	Type          string                 `json:"type" binding:"required,oneof=document_processing compliance_check approval_chain custom"`
+	Type          string                 `json:"type" binding:"required,oneof=document_processing compliance_check approval_chain data_pipeline ai_research media custom"`
 	Configuration map[string]interface{} `json:"configuration"`
 	Steps         []CreateStepRequest    `json:"steps" binding:"required,min=1"`
 	Triggers      []CreateTriggerRequest `json:"triggers" binding:"required,min=1"`

--- a/internal/services/production.go
+++ b/internal/services/production.go
@@ -16,6 +16,12 @@ import (
 	"github.com/Tributary-ai-services/aether-be/pkg/errors"
 )
 
+// RendererResult represents the result from a renderer post-processing step
+type RendererResult struct {
+	URL      string                 `json:"url"`
+	Metadata map[string]interface{} `json:"metadata"`
+}
+
 // ProductionService handles production-related business logic
 type ProductionService struct {
 	neo4j           *database.Neo4jClient
@@ -25,6 +31,7 @@ type ProductionService struct {
 	teamService     *TeamService
 	spaceService    *SpaceService
 	audiModal       *AudiModalService
+	podcastMCP      *MCPClientService
 	logger          *logger.Logger
 }
 
@@ -37,6 +44,7 @@ func NewProductionService(
 	teamService *TeamService,
 	spaceService *SpaceService,
 	audiModal *AudiModalService,
+	podcastMCP *MCPClientService,
 	log *logger.Logger,
 ) *ProductionService {
 	return &ProductionService{
@@ -47,6 +55,7 @@ func NewProductionService(
 		teamService:     teamService,
 		spaceService:    spaceService,
 		audiModal:       audiModal,
+		podcastMCP:      podcastMCP,
 		logger:          log.WithService("production_service"),
 	}
 }
@@ -256,6 +265,20 @@ func (s *ProductionService) ExecuteProducer(ctx context.Context, notebookID stri
 		executionID = executeResp.ExecutionID
 	}
 
+	// If renderer requested, post-process the output
+	if rendererID, ok := req.Context["renderer_id"].(string); ok && rendererID != "" {
+		mediaResult, err := s.executeRenderer(ctx, rendererID, output, req)
+		if err != nil {
+			s.logger.Error("Renderer failed, saving text production without media",
+				zap.String("renderer_id", rendererID),
+				zap.Error(err))
+		} else {
+			production.MediaURL = mediaResult.URL
+			production.MediaMetadata = mediaResult.Metadata
+			production.RendererID = rendererID
+		}
+	}
+
 	responseTimeMs := int(time.Since(startTime).Milliseconds())
 
 	// Generate content from agent output
@@ -413,6 +436,169 @@ func (s *ProductionService) executeInternalProducerAgent(
 	)
 
 	return response.Output, nil
+}
+
+// executeRenderer post-processes a producer's text output through a renderer
+// Currently supports the podcast renderer via podcast-mcp
+func (s *ProductionService) executeRenderer(ctx context.Context, rendererID, textOutput string, req models.ProducerExecuteRequest) (*RendererResult, error) {
+	rendererType, _ := req.Context["renderer_type"].(string)
+
+	switch rendererType {
+	case "podcast":
+		return s.executePodcastRenderer(ctx, textOutput, req)
+	default:
+		return nil, fmt.Errorf("unsupported renderer type: %s", rendererType)
+	}
+}
+
+// executePodcastRenderer calls podcast-mcp to generate audio from a script
+func (s *ProductionService) executePodcastRenderer(ctx context.Context, script string, req models.ProducerExecuteRequest) (*RendererResult, error) {
+	if s.podcastMCP == nil || !s.podcastMCP.IsEnabled() {
+		return nil, fmt.Errorf("podcast MCP service is not available")
+	}
+
+	// Extract renderer config from context
+	ttsProvider, _ := req.Context["tts_provider"].(string)
+	if ttsProvider == "" {
+		ttsProvider = "elevenlabs"
+	}
+
+	speakers, _ := req.Context["speakers"].(string)
+	if speakers == "" {
+		speakers = "Alex, Sam"
+	}
+
+	voiceMapping, _ := req.Context["voice_mapping"].(map[string]interface{})
+
+	introMusicKey, _ := req.Context["intro_music_key"].(string)
+	outroMusicKey, _ := req.Context["outro_music_key"].(string)
+	ambientMusicKey, _ := req.Context["ambient_music_key"].(string)
+
+	// Build MCP tool arguments
+	args := map[string]interface{}{
+		"script":   script,
+		"provider": ttsProvider,
+		"title":    req.Title,
+		"config": map[string]interface{}{
+			"intro_music_key":   introMusicKey,
+			"outro_music_key":   outroMusicKey,
+			"ambient_music_key": ambientMusicKey,
+			"silence_gap_ms":    500,
+		},
+	}
+
+	if voiceMapping != nil {
+		voiceMappingJSON, err := json.Marshal(voiceMapping)
+		if err == nil {
+			args["voice_mapping"] = string(voiceMappingJSON)
+		}
+	}
+
+	s.logger.Info("Invoking podcast renderer via MCP",
+		zap.String("provider", ttsProvider),
+		zap.String("speakers", speakers),
+		zap.String("title", req.Title),
+	)
+
+	// Call podcast-mcp generate_podcast tool
+	resp, err := s.podcastMCP.InvokeTool(ctx, "generate_podcast", args)
+	if err != nil {
+		return nil, fmt.Errorf("podcast MCP call failed: %w", err)
+	}
+
+	if resp.IsError {
+		errText := "unknown error"
+		if len(resp.Content) > 0 {
+			errText = resp.Content[0].Text
+		}
+		return nil, fmt.Errorf("podcast generation failed: %s", errText)
+	}
+
+	// Parse the response - expect JSON with podcast_url, duration, etc.
+	if len(resp.Content) == 0 {
+		return nil, fmt.Errorf("empty response from podcast MCP")
+	}
+
+	var podcastResult map[string]interface{}
+	if err := json.Unmarshal([]byte(resp.Content[0].Text), &podcastResult); err != nil {
+		// If not JSON, treat the text as a URL
+		return &RendererResult{
+			URL: resp.Content[0].Text,
+			Metadata: map[string]interface{}{
+				"provider": ttsProvider,
+				"speakers": speakers,
+			},
+		}, nil
+	}
+
+	// Extract URL and metadata from the result
+	podcastURL, _ := podcastResult["podcast_url"].(string)
+	if podcastURL == "" {
+		podcastURL, _ = podcastResult["url"].(string)
+	}
+
+	metadata := map[string]interface{}{
+		"provider": ttsProvider,
+		"speakers": speakers,
+	}
+	if duration, ok := podcastResult["duration"]; ok {
+		metadata["duration"] = duration
+	}
+	if segments, ok := podcastResult["segments"]; ok {
+		metadata["segments"] = segments
+	}
+
+	s.logger.Info("Podcast rendered successfully",
+		zap.String("url", podcastURL),
+		zap.String("provider", ttsProvider),
+	)
+
+	return &RendererResult{
+		URL:      podcastURL,
+		Metadata: metadata,
+	}, nil
+}
+
+// ListRenderers returns available renderer workflows (workflows with type='renderer' and status='active')
+func (s *ProductionService) ListRenderers(ctx context.Context) ([]map[string]interface{}, error) {
+	query := `
+		MATCH (w:Workflow {type: 'renderer', status: 'active'})
+		RETURN w.id AS id, w.name AS name, w.description AS description,
+			   w.type AS type, w.configuration AS configuration,
+			   w.created_at AS created_at
+		ORDER BY w.name
+	`
+
+	result, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query renderer workflows: %w", err)
+	}
+
+	renderers := make([]map[string]interface{}, 0)
+	for _, record := range result.Records {
+		renderer := map[string]interface{}{}
+		if v, ok := record.Get("id"); ok && v != nil {
+			renderer["id"] = fmt.Sprintf("%v", v)
+		}
+		if v, ok := record.Get("name"); ok && v != nil {
+			renderer["name"] = fmt.Sprintf("%v", v)
+		}
+		if v, ok := record.Get("description"); ok && v != nil {
+			renderer["description"] = fmt.Sprintf("%v", v)
+		}
+		if v, ok := record.Get("type"); ok && v != nil {
+			renderer["type"] = fmt.Sprintf("%v", v)
+		}
+		if config, ok := record.Get("configuration"); ok && config != nil {
+			renderer["configuration"] = config
+		}
+		if createdAt, ok := record.Get("created_at"); ok {
+			renderer["createdAt"] = createdAt
+		}
+		renderers = append(renderers, renderer)
+	}
+
+	return renderers, nil
 }
 
 // getNotebookDocumentContent retrieves the extracted text content from documents in a notebook
@@ -683,7 +869,8 @@ func (s *ProductionService) GetProductionByID(ctx context.Context, productionID,
 		       p.space_type, p.space_id, p.tenant_id,
 		       p.storage_bucket, p.storage_key, p.size_bytes,
 		       p.execution_id, p.tokens_used, p.cost_usd, p.response_time_ms,
-		       p.error_message, p.source_documents, p.search_text,
+		       p.error_message, p.media_url, p.media_metadata, p.renderer_id,
+		       p.source_documents, p.search_text,
 		       p.created_at, p.updated_at
 	`
 
@@ -775,7 +962,8 @@ func (s *ProductionService) ListNotebookProductions(ctx context.Context, noteboo
 		       p.space_type, p.space_id, p.tenant_id,
 		       p.storage_bucket, p.storage_key, p.size_bytes,
 		       p.execution_id, p.tokens_used, p.cost_usd, p.response_time_ms,
-		       p.error_message, p.source_documents, p.created_at, p.updated_at
+		       p.error_message, p.media_url, p.media_metadata, p.renderer_id,
+		       p.source_documents, p.created_at, p.updated_at
 		ORDER BY p.created_at DESC
 		SKIP $offset
 		LIMIT $limit
@@ -919,6 +1107,9 @@ func (s *ProductionService) createProduction(ctx context.Context, production *mo
 			cost_usd: $cost_usd,
 			response_time_ms: $response_time_ms,
 			error_message: $error_message,
+			media_url: $media_url,
+			media_metadata: $media_metadata,
+			renderer_id: $renderer_id,
 			source_documents: $source_documents,
 			search_text: $search_text,
 			created_at: datetime($created_at),
@@ -948,6 +1139,9 @@ func (s *ProductionService) createProduction(ctx context.Context, production *mo
 		"cost_usd":         production.CostUSD,
 		"response_time_ms": production.ResponseTimeMs,
 		"error_message":    production.ErrorMessage,
+		"media_url":        production.MediaURL,
+		"media_metadata":   marshalJSONOrEmpty(production.MediaMetadata),
+		"renderer_id":      production.RendererID,
 		"source_documents": production.SourceDocuments,
 		"search_text":      production.SearchText,
 		"created_at":       production.CreatedAt.Format(time.RFC3339),
@@ -976,6 +1170,9 @@ func (s *ProductionService) updateProduction(ctx context.Context, production *mo
 		    p.cost_usd = $cost_usd,
 		    p.response_time_ms = $response_time_ms,
 		    p.error_message = $error_message,
+		    p.media_url = $media_url,
+		    p.media_metadata = $media_metadata,
+		    p.renderer_id = $renderer_id,
 		    p.search_text = $search_text,
 		    p.updated_at = datetime($updated_at)
 		RETURN p
@@ -994,6 +1191,9 @@ func (s *ProductionService) updateProduction(ctx context.Context, production *mo
 		"cost_usd":         production.CostUSD,
 		"response_time_ms": production.ResponseTimeMs,
 		"error_message":    production.ErrorMessage,
+		"media_url":        production.MediaURL,
+		"media_metadata":   marshalJSONOrEmpty(production.MediaMetadata),
+		"renderer_id":      production.RendererID,
 		"search_text":      production.SearchText,
 		"updated_at":       production.UpdatedAt.Format(time.RFC3339),
 	}
@@ -1166,6 +1366,20 @@ func (s *ProductionService) recordToProduction(record interface{}) (*models.Prod
 	if errorMessage, found := neo4jRecord.Get("p.error_message"); found && errorMessage != nil {
 		production.ErrorMessage = errorMessage.(string)
 	}
+	if mediaURL, found := neo4jRecord.Get("p.media_url"); found && mediaURL != nil {
+		production.MediaURL = mediaURL.(string)
+	}
+	if mediaMetadata, found := neo4jRecord.Get("p.media_metadata"); found && mediaMetadata != nil {
+		if metaStr, ok := mediaMetadata.(string); ok && metaStr != "" {
+			var meta map[string]interface{}
+			if err := json.Unmarshal([]byte(metaStr), &meta); err == nil {
+				production.MediaMetadata = meta
+			}
+		}
+	}
+	if rendererID, found := neo4jRecord.Get("p.renderer_id"); found && rendererID != nil {
+		production.RendererID = rendererID.(string)
+	}
 	if sourceDocuments, found := neo4jRecord.Get("p.source_documents"); found && sourceDocuments != nil {
 		if docs, ok := sourceDocuments.([]interface{}); ok {
 			for _, doc := range docs {
@@ -1326,6 +1540,18 @@ func getContentType(format models.ProductionFormat) string {
 	default:
 		return "text/plain"
 	}
+}
+
+// marshalJSONOrEmpty marshals a map to JSON string, or returns empty string if nil
+func marshalJSONOrEmpty(m map[string]interface{}) string {
+	if m == nil {
+		return ""
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 // NotebookChatResponse represents a response from notebook chat


### PR DESCRIPTION
## Summary
- Add `renderer` workflow type for post-processing producer agent output into different media
- Add podcast/audio production type and format with MediaURL, MediaMetadata, RendererID fields
- Renderer execution via podcast-mcp in the ExecuteProducer flow
- ListRenderers API endpoint (`GET /api/v1/renderers`)
- Neo4j query updates for new production fields

## Test plan
- [ ] Verify `go build ./...` passes
- [ ] Test `GET /api/v1/renderers` returns renderer workflows
- [ ] Test producer execution with renderer context creates production with media fields
- [ ] Verify existing producer execution without renderer still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)