### PR TITLE
feat: skills proxy and skill_ids passthrough for notebook chat

### DIFF
--- a/internal/handlers/agent.go
+++ b/internal/handlers/agent.go
@@ -1131,6 +1131,18 @@ func (h *AgentHandler) GetAgentStats(c *gin.Context) {
 	c.JSON(http.StatusOK, stats)
 }
 
+// ListSkills proxies the skills list request to agent-builder
+func (h *AgentHandler) ListSkills(c *gin.Context) {
+	authToken := extractAuthToken(c)
+	body, err := h.agentService.ProxySkillsList(c.Request.Context(), c.Request.URL.RawQuery, authToken)
+	if err != nil {
+		h.logger.Error("Failed to proxy skills list", zap.Error(err))
+		c.JSON(http.StatusBadGateway, gin.H{"error": "Failed to fetch skills from agent-builder"})
+		return
+	}
+	c.Data(http.StatusOK, "application/json", body)
+}
+
 // truncateString truncates a string to the specified length
 func truncateString(s string, maxLen int) string {
 	if len(s) <= maxLen {

--- a/internal/handlers/production.go
+++ b/internal/handlers/production.go
@@ -901,6 +901,7 @@ type NotebookChatRequest struct {
 	Message        string                `json:"message" binding:"required"`
 	History        []NotebookChatMessage `json:"history,omitempty"`
 	ConversationID string                `json:"conversation_id,omitempty"`
+	SkillIDs       []string              `json:"skill_ids,omitempty"`
 }
 
 // NotebookChatMessage represents a message in the chat history
@@ -1019,6 +1020,7 @@ func (h *ProductionHandler) NotebookChat(c *gin.Context) {
 		userID,
 		authToken,
 		spaceContext,
+		req.SkillIDs,
 	)
 	if err != nil {
 		h.logger.Error("Failed to execute notebook chat", zap.Error(err))

--- a/internal/handlers/routes.go
+++ b/internal/handlers/routes.go
@@ -813,6 +813,9 @@ func (s *APIServer) setupRoutes(keycloakClient *auth.KeycloakClient) {
 		mcpGroup.POST("/invoke", s.MCPHandler.InvokeTool)
 	}
 
+	// Skills routes - proxy to agent-builder
+	api.GET("/skills", s.AgentHandler.ListSkills)
+
 	// Credentials routes - list and manage OAuth credentials
 	credentials := api.Group("/credentials")
 	{

--- a/internal/services/agent.go
+++ b/internal/services/agent.go
@@ -995,6 +995,41 @@ func (s *AgentService) makeAgentBuilderRequest(ctx context.Context, method, path
 	return result, nil
 }
 
+// ProxySkillsList forwards a skills list request to agent-builder and returns the raw JSON response
+func (s *AgentService) ProxySkillsList(ctx context.Context, queryString string, authToken string) ([]byte, error) {
+	url := s.agentBuilderURL + "/skills"
+	if queryString != "" {
+		url += "?" + queryString
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, errors.InternalWithCause("Failed to create skills request", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		s.logger.Error("Agent-builder skills request failed", zap.String("url", url), zap.Error(err))
+		return nil, errors.ExternalService("Agent-builder service unavailable", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.InternalWithCause("Failed to read skills response", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, errors.ExternalService(fmt.Sprintf("Agent-builder skills error: %s", string(body)), nil)
+	}
+
+	return body, nil
+}
+
 // Helper methods for Neo4j operations
 
 func (s *AgentService) createAgentInNeo4j(ctx context.Context, agent *models.Agent) error {

--- a/internal/services/production.go
+++ b/internal/services/production.go
@@ -1933,6 +1933,7 @@ func (s *ProductionService) ExecuteNotebookChat(
 	userID string,
 	authToken string,
 	spaceCtx *models.SpaceContext,
+	skillIDs []string,
 ) (*NotebookChatResponse, error) {
 	// Verify notebook exists and user has access
 	notebook, err := s.notebookService.GetNotebookByID(ctx, notebookID, userID, spaceCtx)
@@ -1995,11 +1996,20 @@ func (s *ProductionService) ExecuteNotebookChat(
 		executeReq.SelectedDocuments = audimodalFileIDs
 	}
 
+	// Pass requested skill IDs so agent-builder can activate specific MCP tools
+	if len(skillIDs) > 0 {
+		if executeReq.Context == nil {
+			executeReq.Context = make(map[string]interface{})
+		}
+		executeReq.Context["skill_ids"] = skillIDs
+	}
+
 	s.logger.Info("Executing notebook chat via agent-builder",
 		zap.String("notebook_id", notebook.ID),
 		zap.String("audimodal_tenant_id", audimodalTenantID),
 		zap.Int("history_length", len(history)),
 		zap.Int("file_ids", len(audimodalFileIDs)),
+		zap.Int("skill_ids", len(skillIDs)),
 		zap.String("user_id", userID),
 	)
 


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/skills` that proxies to agent-builder so the frontend can list available skills
- Extend the notebook chat request with optional `skill_ids` forwarded to agent-builder as execution context, letting users activate specific MCP tools per chat

## Test plan
- [ ] `GET /api/v1/skills` returns agent-builder skills list (pass-through)
- [ ] `GET /api/v1/skills?size=100` forwards query string
- [ ] Notebook chat with `skill_ids` passes them into agent-builder context
- [ ] Notebook chat without `skill_ids` works unchanged
- [ ] Agent-builder 5xx surfaces as 502 from aether-be

🤖 Generated with [Claude Code](https://claude.com/claude-code)