### PR TITLE
feat: streaming hub, CE workflow/security mirror, MCP tool publisher, /streams/stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+go-events/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,16 @@ RUN apk add --no-cache git ca-certificates tzdata
 # Set working directory
 WORKDIR /app
 
-# Copy go mod files
-COPY go.mod go.sum ./
-
-# Download dependencies
-RUN go mod download
+# Copy the shared go-events module
+COPY go-events/ /go-events/
 
 # Copy source code
 COPY . .
 
-# Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main cmd/server/main.go
+# Update replace directive for container paths and build
+RUN sed -i 's|=> ../aether-shared/go-events|=> /go-events|' go.mod && \
+    go mod download && \
+    CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main cmd/server/main.go
 
 # Final stage
 FROM alpine:latest

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REGISTRY="registry-api.tas.scharber.com"
+IMAGE="${REGISTRY}/aether-backend"
+
+echo "=== Building aether-be ==="
+
+# Copy shared go-events module into build context
+echo "Copying go-events module into build context..."
+rm -rf "${SCRIPT_DIR}/go-events"
+cp -r "${SCRIPT_DIR}/../aether-shared/go-events" "${SCRIPT_DIR}/go-events"
+
+# Build
+echo "Building Docker image..."
+docker build -t "${IMAGE}:latest" "${SCRIPT_DIR}"
+
+# Clean up
+rm -rf "${SCRIPT_DIR}/go-events"
+
+# Push
+echo "Pushing to registry..."
+docker push "${IMAGE}:latest"
+
+echo "=== Done: ${IMAGE}:latest ==="

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Tributary-ai-services/aether-be/internal/auth"
 	"github.com/Tributary-ai-services/aether-be/internal/config"
 	"github.com/Tributary-ai-services/aether-be/internal/database"
+	"github.com/Tributary-ai-services/aether-be/internal/events"
 	"github.com/Tributary-ai-services/aether-be/internal/handlers"
 	"github.com/Tributary-ai-services/aether-be/internal/logger"
 	"github.com/Tributary-ai-services/aether-be/internal/metrics"
@@ -168,9 +169,38 @@ func main() {
 		consumerCfg := streaming.DefaultConsumerConfig(cfg.Kafka.Brokers)
 		streamingConsumer = streaming.NewConsumer(streamingHub, consumerCfg, zapLogger)
 		apiServer.StreamHandler.SetStreamingHub(streamingHub)
+
+		// Wire MCP CloudEvents publisher → tas.activity.mcp
+		mcpPublisher := events.NewMCPPublisher(events.MCPConfig{
+			Brokers: cfg.Kafka.Brokers,
+			Logger:  zapLogger,
+		})
+		apiServer.MCPHandler.SetMCPPublisher(mcpPublisher)
 		appLogger.Info("Streaming hub initialized — Live Streams will receive Kafka events")
 	} else {
 		appLogger.Info("Kafka disabled — Live Streams will use legacy Neo4j polling")
+	}
+
+	// Open TimescaleDB pool for Live Streams summary cards
+	if dsn := os.Getenv("TIMESCALE_DSN"); dsn != "" {
+		tsdb, err := sql.Open("postgres", dsn)
+		if err != nil {
+			appLogger.Warn("TimescaleDB pool open failed — /streams/stats will return unavailable", zap.Error(err))
+		} else {
+			tsdb.SetMaxOpenConns(5)
+			tsdb.SetMaxIdleConns(2)
+			tsdb.SetConnMaxLifetime(time.Hour)
+			if pingErr := tsdb.Ping(); pingErr != nil {
+				appLogger.Warn("TimescaleDB ping failed — /streams/stats will return unavailable", zap.Error(pingErr))
+				tsdb.Close()
+			} else {
+				statsService := services.NewStreamStatsService(tsdb, appLogger)
+				apiServer.StreamHandler.SetStatsService(statsService)
+				appLogger.Info("TimescaleDB stats service connected — /streams/stats backed by events_1m")
+			}
+		}
+	} else {
+		appLogger.Info("TIMESCALE_DSN unset — /streams/stats will return unavailable")
 	}
 
 	// Create HTTP server

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -166,7 +166,12 @@ func main() {
 	if cfg.Kafka.Enabled && len(cfg.Kafka.Brokers) > 0 {
 		zapLogger, _ := zap.NewProduction()
 		streamingHub := streaming.NewHub(zapLogger)
-		consumerCfg := streaming.DefaultConsumerConfig(cfg.Kafka.Brokers)
+		// Use the pod hostname (or any other unique-per-instance identifier) as
+		// the consumer-group suffix so each replica subscribes independently and
+		// fans every CE out through its own in-memory hub. Without this, partitions
+		// are split across replicas and a WS client connected to pod A never sees
+		// events for partitions owned by pod B.
+		consumerCfg := streaming.DefaultConsumerConfig(cfg.Kafka.Brokers, os.Getenv("HOSTNAME"))
 		streamingConsumer = streaming.NewConsumer(streamingHub, consumerCfg, zapLogger)
 		apiServer.StreamHandler.SetStreamingHub(streamingHub)
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Tributary-ai-services/aether-be/internal/logger"
 	"github.com/Tributary-ai-services/aether-be/internal/metrics"
 	"github.com/Tributary-ai-services/aether-be/internal/services"
+	"github.com/Tributary-ai-services/aether-be/internal/streaming"
 )
 
 func main() {
@@ -159,6 +160,19 @@ func main() {
 		appLogger,
 	)
 
+	// Initialize streaming event hub + Kafka consumer (if Kafka is enabled)
+	var streamingConsumer *streaming.Consumer
+	if cfg.Kafka.Enabled && len(cfg.Kafka.Brokers) > 0 {
+		zapLogger, _ := zap.NewProduction()
+		streamingHub := streaming.NewHub(zapLogger)
+		consumerCfg := streaming.DefaultConsumerConfig(cfg.Kafka.Brokers)
+		streamingConsumer = streaming.NewConsumer(streamingHub, consumerCfg, zapLogger)
+		apiServer.StreamHandler.SetStreamingHub(streamingHub)
+		appLogger.Info("Streaming hub initialized — Live Streams will receive Kafka events")
+	} else {
+		appLogger.Info("Kafka disabled — Live Streams will use legacy Neo4j polling")
+	}
+
 	// Create HTTP server
 	server := &http.Server{
 		Addr:         ":" + cfg.Server.Port,
@@ -174,6 +188,12 @@ func main() {
 
 	go metricsCollector.Start(ctx)
 	appLogger.Info("Metrics collection started")
+
+	// Start streaming consumer (if enabled)
+	if streamingConsumer != nil {
+		streamingConsumer.Start(ctx)
+		appLogger.Info("Streaming consumer started — reading from Kafka activity + compliance topics")
+	}
 
 	// Start stale production cleanup worker
 	go apiServer.ProductionCleanupWorker.Start(ctx)
@@ -197,8 +217,12 @@ func main() {
 
 	appLogger.Info("Shutting down server...")
 
-	// Stop metrics collection and cleanup worker
-	cancel() // This stops the metrics collector and cleanup worker contexts
+	// Stop metrics collection, streaming consumer, and cleanup worker
+	cancel() // This stops the metrics collector, streaming consumer, and cleanup worker contexts
+	if streamingConsumer != nil {
+		streamingConsumer.Stop()
+		appLogger.Info("Streaming consumer stopped")
+	}
 	metricsCollector.Stop()
 	apiServer.ProductionCleanupWorker.Stop()
 	appLogger.Info("Metrics collection and production cleanup worker stopped")

--- a/go.mod
+++ b/go.mod
@@ -106,3 +106,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+require github.com/Tributary-ai-services/aether-shared/go-events v0.0.0
+
+replace github.com/Tributary-ai-services/aether-shared/go-events => ../aether-shared/go-events

--- a/internal/events/mcp_publisher.go
+++ b/internal/events/mcp_publisher.go
@@ -1,0 +1,126 @@
+// Package events publishes CloudEvents 1.0 activity events from aether-be
+// to Kafka for the TAS Live Streams pipeline.
+package events
+
+import (
+	"context"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+	"go.uber.org/zap"
+
+	tasevents "github.com/Tributary-ai-services/aether-shared/go-events"
+	"github.com/Tributary-ai-services/aether-shared/go-events/kafkabind"
+	"github.com/Tributary-ai-services/aether-shared/go-events/payloads"
+	"github.com/Tributary-ai-services/aether-shared/go-events/topics"
+)
+
+const ceSource = "urn:tas:service:aether-be:mcp-proxy"
+
+type kafkaWriter interface {
+	WriteMessages(ctx context.Context, msgs ...kafka.Message) error
+	Close() error
+}
+
+// MCPPublisher emits com.tas.activity.mcp.tool_invoked CloudEvents to
+// tas.activity.mcp around aether-be's MCP proxy tool dispatch. A nil
+// receiver is safe — every method becomes a no-op so callers don't need
+// nil checks.
+type MCPPublisher struct {
+	writer  kafkaWriter
+	logger  *zap.Logger
+	timeout time.Duration
+}
+
+// MCPConfig configures the MCPPublisher.
+type MCPConfig struct {
+	Brokers      []string
+	Topic        string
+	Logger       *zap.Logger
+	WriteTimeout time.Duration
+}
+
+// NewMCPPublisher returns an MCPPublisher backed by a kafka-go Writer.
+// Returns nil if brokers is empty so callers can pass through without
+// branches at every call site.
+func NewMCPPublisher(cfg MCPConfig) *MCPPublisher {
+	if len(cfg.Brokers) == 0 {
+		return nil
+	}
+	topic := cfg.Topic
+	if topic == "" {
+		topic = topics.ActivityMCP
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	timeout := cfg.WriteTimeout
+	if timeout == 0 {
+		timeout = 2 * time.Second
+	}
+	writer := &kafka.Writer{
+		Addr:         kafka.TCP(cfg.Brokers...),
+		Topic:        topic,
+		Balancer:     &kafka.Hash{},
+		BatchTimeout: 10 * time.Millisecond,
+		WriteTimeout: timeout,
+		RequiredAcks: kafka.RequireOne,
+	}
+	return &MCPPublisher{writer: writer, logger: logger, timeout: timeout}
+}
+
+// NewMCPPublisherWithWriter is for tests.
+func NewMCPPublisherWithWriter(w kafkaWriter, logger *zap.Logger) *MCPPublisher {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &MCPPublisher{writer: w, logger: logger, timeout: 2 * time.Second}
+}
+
+// PublishToolInvoked emits com.tas.activity.mcp.tool_invoked. subject is
+// the server ID so frontend filters can pivot per-server.
+func (p *MCPPublisher) PublishToolInvoked(ctx context.Context, tenantID, userID, requestID string, payload payloads.MCPToolInvoked) {
+	if p == nil || p.writer == nil {
+		return
+	}
+	sev := tasevents.SeverityInfo
+	if !payload.Success {
+		sev = tasevents.SeverityMedium
+	}
+	ce := tasevents.New(payloads.TypeMCPToolInvoked, ceSource,
+		tasevents.WithTenant(tenantID, ""),
+		tasevents.WithUser(userID),
+		tasevents.WithRequest(requestID),
+		tasevents.WithSubject(payload.ServerID),
+		tasevents.WithSeverity(sev),
+		tasevents.WithData(payload),
+	)
+
+	value, headers, err := kafkabind.Encode(ce)
+	if err != nil {
+		p.logger.Warn("mcp events: encode failed", zap.Error(err))
+		return
+	}
+
+	writeCtx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+
+	msg := kafka.Message{
+		Key:     kafkabind.MessageKey(ce),
+		Value:   value,
+		Headers: headers,
+		Time:    ce.Time,
+	}
+	if err := p.writer.WriteMessages(writeCtx, msg); err != nil {
+		p.logger.Warn("mcp events: publish failed", zap.Error(err))
+	}
+}
+
+// Close flushes pending messages.
+func (p *MCPPublisher) Close() error {
+	if p == nil || p.writer == nil {
+		return nil
+	}
+	return p.writer.Close()
+}

--- a/internal/handlers/mcp_handler.go
+++ b/internal/handlers/mcp_handler.go
@@ -8,10 +8,12 @@ import (
 	"time"
 
 	"github.com/Tributary-ai-services/aether-be/internal/config"
+	"github.com/Tributary-ai-services/aether-be/internal/events"
 	"github.com/Tributary-ai-services/aether-be/internal/logger"
 	"github.com/Tributary-ai-services/aether-be/internal/middleware"
 	"github.com/Tributary-ai-services/aether-be/internal/models"
 	"github.com/Tributary-ai-services/aether-be/internal/services"
+	"github.com/Tributary-ai-services/aether-shared/go-events/payloads"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
@@ -25,10 +27,18 @@ type MCPHandler struct {
 	serverInfos     []MCPServerInfo
 	cfg             *config.Config
 	logger          *zap.Logger
+	mcpPublisher    *events.MCPPublisher
 
 	// Health cache with TTL
 	healthMu    sync.RWMutex
 	healthCache map[string]healthCacheEntry
+}
+
+// SetMCPPublisher wires the CloudEvents publisher used to emit
+// com.tas.activity.mcp.tool_invoked. Pass nil to disable publishing —
+// MCPPublisher methods no-op on a nil receiver.
+func (h *MCPHandler) SetMCPPublisher(p *events.MCPPublisher) {
+	h.mcpPublisher = p
 }
 
 // healthCacheEntry holds a cached health check result with expiry
@@ -316,6 +326,11 @@ func (h *MCPHandler) InvokeTool(c *gin.Context) {
 		zap.String("connection_id", req.ConnectionID),
 	)
 
+	tenantID := stringFromCtx(c, "tenant_id")
+	userID := stringFromCtx(c, "user_id")
+	requestID := c.GetHeader("X-Request-ID")
+	start := time.Now()
+
 	// If a connectionId was provided and this is an infrastructure server, resolve credentials
 	if req.ConnectionID != "" {
 		if _, isInfra := infrastructureServerTypes[req.ServerID]; isInfra {
@@ -332,6 +347,7 @@ func (h *MCPHandler) InvokeTool(c *gin.Context) {
 			return
 		}
 		result, err := h.napkinService.InvokeTool(c.Request.Context(), req.Tool, req.Params)
+		h.publishToolInvoked(c.Request.Context(), tenantID, userID, requestID, req, start, err)
 		if err != nil {
 			h.logger.Error("Failed to invoke Napkin tool", zap.Error(err), zap.String("tool", req.Tool))
 			c.JSON(http.StatusBadGateway, gin.H{"error": "Tool invocation failed: " + err.Error()})
@@ -344,6 +360,7 @@ func (h *MCPHandler) InvokeTool(c *gin.Context) {
 	// Check generic MCP clients
 	if client, ok := h.mcpClients[req.ServerID]; ok {
 		result, err := client.InvokeTool(c.Request.Context(), req.Tool, req.Params)
+		h.publishToolInvoked(c.Request.Context(), tenantID, userID, requestID, req, start, err)
 		if err != nil {
 			h.logger.Error("Failed to invoke tool", zap.String("server", req.ServerID), zap.Error(err), zap.String("tool", req.Tool))
 			c.JSON(http.StatusBadGateway, gin.H{"error": "Tool invocation failed: " + err.Error()})
@@ -354,6 +371,30 @@ func (h *MCPHandler) InvokeTool(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusNotFound, gin.H{"error": "Server not found or tool invocation not supported: " + req.ServerID})
+}
+
+// publishToolInvoked emits com.tas.activity.mcp.tool_invoked.
+func (h *MCPHandler) publishToolInvoked(ctx context.Context, tenantID, userID, requestID string, req MCPInvokeRequest, start time.Time, err error) {
+	payload := payloads.MCPToolInvoked{
+		ServerID:   req.ServerID,
+		ToolName:   req.Tool,
+		DurationMS: time.Since(start).Milliseconds(),
+		Success:    err == nil,
+	}
+	if err != nil {
+		payload.Error = err.Error()
+	}
+	h.mcpPublisher.PublishToolInvoked(ctx, tenantID, userID, requestID, payload)
+}
+
+// stringFromCtx pulls a Gin context key as a string, returning "" if absent.
+func stringFromCtx(c *gin.Context, key string) string {
+	if v, ok := c.Get(key); ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
 }
 
 // TestConnection tests connectivity through an MCP server's bridge using a lightweight tool invocation

--- a/internal/handlers/routes.go
+++ b/internal/handlers/routes.go
@@ -801,6 +801,9 @@ func (s *APIServer) setupRoutes(keycloakClient *auth.KeycloakClient) {
 		// Stream analytics
 		streams.GET("/analytics", s.StreamHandler.GetStreamAnalytics)
 		streams.GET("/analytics/realtime", s.StreamHandler.GetRealtimeAnalytics)
+
+		// Live Streams summary cards (TimescaleDB-backed)
+		streams.GET("/stats", s.StreamHandler.GetStreamStats)
 	}
 
 	// MCP server management routes

--- a/internal/handlers/routes.go
+++ b/internal/handlers/routes.go
@@ -134,7 +134,7 @@ func NewAPIServer(
 	organizationHandler := NewOrganizationHandler(organizationService, userService, log)
 	spaceHandler := NewSpaceHandler(spaceContextService, spaceService, userService, organizationService, log)
 	agentHandler := NewAgentHandler(agentService, userService, teamService, log)
-	streamHandler := NewStreamHandler(streamService, log)
+	streamHandler := NewStreamHandler(streamService, nil, log) // hub wired from main.go via SetStreamingHub
 	healthHandler := NewHealthHandler(neo4j, storageService, kafkaService, log)
 	loggingHandler := NewLoggingHandler(log)
 	vectorSearchHandler := NewVectorSearchHandler(notebookService, documentService, userService, &cfg.DeepLake, log)

--- a/internal/handlers/stream.go
+++ b/internal/handlers/stream.go
@@ -15,20 +15,24 @@ import (
 	"github.com/Tributary-ai-services/aether-be/internal/middleware"
 	"github.com/Tributary-ai-services/aether-be/internal/models"
 	"github.com/Tributary-ai-services/aether-be/internal/services"
+	"github.com/Tributary-ai-services/aether-be/internal/streaming"
 	"github.com/Tributary-ai-services/aether-be/pkg/errors"
 )
 
 // StreamHandler handles live streaming HTTP requests and WebSocket connections
 type StreamHandler struct {
 	streamService *services.StreamService
+	hub           *streaming.Hub
 	logger        *logger.Logger
 	upgrader      websocket.Upgrader
 }
 
-// NewStreamHandler creates a new stream handler
-func NewStreamHandler(streamService *services.StreamService, log *logger.Logger) *StreamHandler {
+// NewStreamHandler creates a new stream handler. The hub is optional — pass nil
+// to use only the legacy Neo4j-backed stream service.
+func NewStreamHandler(streamService *services.StreamService, hub *streaming.Hub, log *logger.Logger) *StreamHandler {
 	return &StreamHandler{
 		streamService: streamService,
+		hub:           hub,
 		logger:        log.WithService("stream_handler"),
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
@@ -39,6 +43,12 @@ func NewStreamHandler(streamService *services.StreamService, log *logger.Logger)
 			WriteBufferSize: 1024,
 		},
 	}
+}
+
+// SetStreamingHub wires the Kafka-backed streaming hub into the handler.
+// Called from main.go after the consumer is initialized.
+func (h *StreamHandler) SetStreamingHub(hub *streaming.Hub) {
+	h.hub = hub
 }
 
 // CreateStreamSource creates a new stream source
@@ -522,7 +532,7 @@ func (h *StreamHandler) StreamEvents(c *gin.Context) {
 
 	// Parse filters from query parameters
 	filters := models.StreamFilters{}
-	
+
 	if sourceIDs := c.Query("source_ids"); sourceIDs != "" {
 		filters.SourceIDs = parseCommaSeparated(sourceIDs)
 	}
@@ -541,7 +551,7 @@ func (h *StreamHandler) StreamEvents(c *gin.Context) {
 		}
 	}
 
-	h.logger.Info("Starting WebSocket event stream", 
+	h.logger.Info("Starting WebSocket event stream",
 		zap.String("user_id", userID),
 		zap.String("tenant_id", spaceContext.TenantID),
 		zap.Any("filters", filters))
@@ -552,11 +562,19 @@ func (h *StreamHandler) StreamEvents(c *gin.Context) {
 		h.logger.Error("Failed to upgrade WebSocket connection", zap.Error(err))
 		return
 	}
+
+	// If the streaming hub is available, use the Kafka-backed event delivery.
+	// Otherwise fall back to the legacy Neo4j-based analytics polling.
+	if h.hub != nil {
+		h.handleHubWebSocket(conn, userID, spaceContext.TenantID, filters.EventTypes)
+		return
+	}
+
 	defer conn.Close()
 
 	// Create stream connection
 	streamConn := models.NewStreamConnection(userID, spaceContext.TenantID, filters)
-	
+
 	// Register connection with stream service
 	h.streamService.AddStreamConnection(streamConn)
 	defer h.streamService.RemoveStreamConnection(streamConn.ID)
@@ -566,7 +584,7 @@ func (h *StreamHandler) StreamEvents(c *gin.Context) {
 		Type:      "connection_established",
 		Timestamp: time.Now(),
 	}
-	
+
 	if err := conn.WriteJSON(confirmationMsg); err != nil {
 		h.logger.Error("Failed to send connection confirmation", zap.Error(err))
 		return
@@ -574,6 +592,26 @@ func (h *StreamHandler) StreamEvents(c *gin.Context) {
 
 	// Handle WebSocket connection
 	h.handleWebSocketConnection(conn, streamConn)
+}
+
+// handleHubWebSocket registers the WS connection with the streaming hub so it
+// receives CloudEvents from Kafka in real time.
+func (h *StreamHandler) handleHubWebSocket(ws *websocket.Conn, userID, tenantID string, typeFilter []string) {
+	connID := userID + "-" + time.Now().Format("20060102150405")
+
+	sc := streaming.NewConn(connID, tenantID, ws, typeFilter)
+	h.hub.Register(sc)
+	defer h.hub.Unregister(connID)
+
+	// Send connection confirmation as a plain JSON message (not a CE)
+	ws.WriteJSON(map[string]interface{}{
+		"type":      "connection_established",
+		"timestamp": time.Now(),
+	})
+
+	// ReadPump blocks until the client disconnects
+	go sc.WritePump()
+	sc.ReadPump()
 }
 
 // handleWebSocketConnection handles an active WebSocket connection

--- a/internal/handlers/stream.go
+++ b/internal/handlers/stream.go
@@ -22,9 +22,16 @@ import (
 // StreamHandler handles live streaming HTTP requests and WebSocket connections
 type StreamHandler struct {
 	streamService *services.StreamService
+	statsService  *services.StreamStatsService
 	hub           *streaming.Hub
 	logger        *logger.Logger
 	upgrader      websocket.Upgrader
+}
+
+// SetStatsService wires the TimescaleDB-backed stats service. Pass nil to
+// disable — GetStreamStats will return a 0-value response with source=unavailable.
+func (h *StreamHandler) SetStatsService(s *services.StreamStatsService) {
+	h.statsService = s
 }
 
 // NewStreamHandler creates a new stream handler. The hub is optional — pass nil
@@ -503,6 +510,34 @@ func (h *StreamHandler) GetStreamAnalytics(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, analytics)
+}
+
+// GetStreamStats returns real-time event throughput for the Live Streams
+// summary cards. Backed by the TimescaleDB events_1m continuous aggregate.
+// @Summary Get live stream stats
+// @Description Returns events/min and active source count over the last 5 minutes
+// @Tags streams
+// @Produce json
+// @Security Bearer
+// @Success 200 {object} services.StreamStats
+// @Router /api/v1/streams/stats [get]
+func (h *StreamHandler) GetStreamStats(c *gin.Context) {
+	if h.statsService == nil {
+		c.JSON(http.StatusOK, services.StreamStats{Source: "unavailable", BySeverity: map[string]int64{}, WindowMinutes: 5})
+		return
+	}
+
+	tenantID := ""
+	if spaceContext, err := middleware.GetSpaceContext(c); err == nil && spaceContext != nil {
+		tenantID = spaceContext.TenantID
+	}
+
+	stats, err := h.statsService.GetStats(c.Request.Context(), tenantID)
+	if err != nil {
+		// stats already populated with safe defaults; log + still return 200
+		h.logger.Warn("stream stats query failed, returning fallback", zap.Error(err))
+	}
+	c.JSON(http.StatusOK, stats)
 }
 
 // StreamEvents handles WebSocket connections for real-time event streaming

--- a/internal/services/audimodal.go
+++ b/internal/services/audimodal.go
@@ -523,8 +523,15 @@ func (s *AudiModalService) getAudiModalMapping(ctx context.Context, aetherTenant
 
 // makeRequest is a helper function to make HTTP requests to AudiModal
 func (s *AudiModalService) makeRequest(ctx context.Context, method, path string, body interface{}) (*http.Response, error) {
+	return s.makeRequestWithHeaders(ctx, method, path, body, nil)
+}
+
+// makeRequestWithHeaders mirrors makeRequest but lets the caller add extra request headers
+// (e.g. X-Aether-Tenant-Id so AudiModal can mirror the canonical tenant id back onto its
+// activity CloudEvents).
+func (s *AudiModalService) makeRequestWithHeaders(ctx context.Context, method, path string, body interface{}, extra map[string]string) (*http.Response, error) {
 	url := s.baseURL + path
-	
+
 	var reqBody []byte
 	var err error
 	if body != nil {
@@ -533,16 +540,32 @@ func (s *AudiModalService) makeRequest(ctx context.Context, method, path string,
 			return nil, fmt.Errorf("failed to marshal request body: %w", err)
 		}
 	}
-	
+
 	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	
+
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-API-Key", s.apiKey)
-	
+	for k, v := range extra {
+		if v != "" {
+			req.Header.Set(k, v)
+		}
+	}
+
 	return s.client.Do(req)
+}
+
+// aetherTenantHeader returns a header map carrying the canonical Aether tenant id under
+// X-Aether-Tenant-Id, or nil when the id is empty. AudiModal reads this header and writes
+// it into the `tenantid` extension of activity CloudEvents so downstream WS hub filters
+// match without needing a separate tenant-mapping lookup.
+func aetherTenantHeader(aetherTenantID string) map[string]string {
+	if aetherTenantID == "" {
+		return nil
+	}
+	return map[string]string{"X-Aether-Tenant-Id": aetherTenantID}
 }
 
 // SubmitProcessingJob submits a document processing job to AudiModal
@@ -680,9 +703,10 @@ func (s *AudiModalService) SubmitProcessingJob(ctx context.Context, tenantID str
 
 			s.logger.Info("File registered, triggering text extraction",
 				zap.String("file_id", processResult.Data.ID),
-				zap.String("tenant_id", processResult.Data.TenantID))
+				zap.String("tenant_id", processResult.Data.TenantID),
+				zap.String("aether_tenant_id", tenantID))
 
-			if err := s.TriggerFileProcessingWithOptions(ctx, processResult.Data.TenantID, processResult.Data.ID, procOptions); err != nil {
+			if err := s.TriggerFileProcessingForAetherTenant(ctx, processResult.Data.TenantID, tenantID, processResult.Data.ID, procOptions); err != nil {
 				s.logger.Warn("Failed to trigger file processing - file registered but extraction not started",
 					zap.String("file_id", processResult.Data.ID),
 					zap.Error(err))
@@ -763,9 +787,21 @@ func (s *AudiModalService) TriggerFileProcessing(ctx context.Context, tenantUUID
 	return s.TriggerFileProcessingWithOptions(ctx, tenantUUID, fileID, nil)
 }
 
-// TriggerFileProcessingWithOptions triggers text extraction with custom options including DLP and redaction settings
+// TriggerFileProcessingWithOptions triggers text extraction with custom options including DLP and redaction settings.
+// canonicalTenantID is the upstream Aether tenant id (e.g. "tenant_1766596584"); when non-empty it's forwarded
+// as X-Aether-Tenant-Id so AudiModal stamps activity CloudEvents with the value the WS hub broadcasts on.
 func (s *AudiModalService) TriggerFileProcessingWithOptions(ctx context.Context, tenantUUID, fileID string, options *ProcessingOptions) error {
-	url := fmt.Sprintf("/api/v1/tenants/%s/files/%s/process", tenantUUID, fileID)
+	return s.triggerFileProcessing(ctx, tenantUUID, "", fileID, options)
+}
+
+// TriggerFileProcessingForAetherTenant is the canonical-aware variant; pass the upstream Aether tenant id
+// (tenant_<id>) so AudiModal stamps the activity CloudEvent with the same identifier the WS hub keys on.
+func (s *AudiModalService) TriggerFileProcessingForAetherTenant(ctx context.Context, tenantUUID, aetherTenantID, fileID string, options *ProcessingOptions) error {
+	return s.triggerFileProcessing(ctx, tenantUUID, aetherTenantID, fileID, options)
+}
+
+func (s *AudiModalService) triggerFileProcessing(ctx context.Context, tenantUUID, aetherTenantID, fileID string, options *ProcessingOptions) error {
+	path := fmt.Sprintf("/api/v1/tenants/%s/files/%s/process", tenantUUID, fileID)
 
 	// Use fixed_size_text as the default strategy since "auto" is not supported
 	req := map[string]interface{}{
@@ -792,10 +828,11 @@ func (s *AudiModalService) TriggerFileProcessingWithOptions(ctx context.Context,
 
 	s.logger.Info("Triggering file processing in AudiModal",
 		zap.String("tenant_uuid", tenantUUID),
+		zap.String("aether_tenant_id", aetherTenantID),
 		zap.String("file_id", fileID),
 		zap.Any("request", req))
 
-	resp, err := s.makeRequest(ctx, http.MethodPost, url, req)
+	resp, err := s.makeRequestWithHeaders(ctx, http.MethodPost, path, req, aetherTenantHeader(aetherTenantID))
 	if err != nil {
 		return fmt.Errorf("failed to trigger file processing: %w", err)
 	}
@@ -956,6 +993,13 @@ func (s *AudiModalService) RegisterFileFromS3(ctx context.Context, tenantID stri
 		apiKey = "default-api-key"
 	}
 	req.Header.Set("X-API-Key", apiKey)
+	// Forward the canonical Aether tenant id (e.g. tenant_1766596584) so
+	// AudiModal stamps activity CloudEvents with the same value the WS hub
+	// keys broadcasts on. Without this, audimodal emits its internal UUID
+	// and the hub's per-tenant filter drops every event before fan-out.
+	if tenantID != "" {
+		req.Header.Set("X-Aether-Tenant-Id", tenantID)
+	}
 
 	s.logger.Info("Registering S3 file with AudiModal",
 		zap.String("document_id", documentID),

--- a/internal/services/kafka.go
+++ b/internal/services/kafka.go
@@ -11,7 +11,31 @@ import (
 
 	"github.com/Tributary-ai-services/aether-be/internal/config"
 	"github.com/Tributary-ai-services/aether-be/internal/logger"
+	tasevents "github.com/Tributary-ai-services/aether-shared/go-events"
+	"github.com/Tributary-ai-services/aether-shared/go-events/kafkabind"
+	"github.com/Tributary-ai-services/aether-shared/go-events/topics"
 )
+
+// ceCESource is the CloudEvents source URI for events emitted by aether-be.
+const ceSource = "urn:tas:service:aether-be"
+
+// ceMapping defines which legacy EventTypes get mirrored as CloudEvents
+// during the migration window. Unmapped events publish legacy-only.
+type ceMappingEntry struct {
+	ceType string
+	topic  string
+	sev    tasevents.Severity
+}
+
+var ceMapping = map[EventType]ceMappingEntry{
+	EventWorkflowFileUploaded:    {"com.tas.activity.workflow.started", topics.ActivityWorkflows, tasevents.SeverityInfo},
+	EventWorkflowDocumentEvent:   {"com.tas.activity.workflow.step_completed", topics.ActivityWorkflows, tasevents.SeverityInfo},
+	EventWorkflowCompleted:       {"com.tas.activity.workflow.completed", topics.ActivityWorkflows, tasevents.SeverityInfo},
+	EventWorkflowFailed:          {"com.tas.activity.workflow.failed", topics.ActivityWorkflows, tasevents.SeverityHigh},
+	EventSecurityThreatDetected:  {"com.tas.activity.security.threat_detected", topics.ActivitySecurity, tasevents.SeverityHigh},
+	EventSecurityReviewCompleted: {"com.tas.activity.security.review_completed", topics.ActivitySecurity, tasevents.SeverityInfo},
+	EventSecurityPolicyViolation: {"com.tas.activity.security.policy_violation", topics.ActivitySecurity, tasevents.SeverityHigh},
+}
 
 // KafkaService handles Kafka operations
 type KafkaService struct {
@@ -207,7 +231,70 @@ func (k *KafkaService) PublishEvent(ctx context.Context, event Event) error {
 		zap.Float64("duration_ms", duration),
 	)
 
+	// CloudEvents mirror — dual-publish for workflow + security events so the
+	// Live Streams pipeline (Spark + aether-be consumer) sees them on the
+	// canonical tas.activity.* topics. Shared event_id keeps consumers
+	// idempotent across legacy and CE envelopes during the migration window.
+	k.publishCEMirror(ctx, event)
+
 	return nil
+}
+
+// publishCEMirror writes a CloudEvents structured-mode envelope to the
+// mapped tas.activity.* topic for events that are part of the migration
+// scope. It is fire-and-forget: failures are logged but never returned —
+// the legacy publish has already succeeded by the time this runs and we
+// don't want to fail the caller for the mirror.
+func (k *KafkaService) publishCEMirror(ctx context.Context, event Event) {
+	mapping, ok := ceMapping[event.Type]
+	if !ok {
+		return
+	}
+
+	// Reuse the same UUID as the legacy envelope so consumers can dedupe.
+	ce := tasevents.NewWithID(event.ID, mapping.ceType, ceSource,
+		tasevents.WithSubject(event.Subject),
+		tasevents.WithUser(event.UserID),
+		tasevents.WithSeverity(mapping.sev),
+		tasevents.WithTime(event.Timestamp),
+		tasevents.WithData(event.Data),
+	)
+
+	value, headers, err := kafkabind.Encode(ce)
+	if err != nil {
+		k.logger.Warn("CE mirror: encode failed",
+			zap.String("event_id", event.ID),
+			zap.String("ce_type", mapping.ceType),
+			zap.Error(err),
+		)
+		return
+	}
+
+	msg := kafka.Message{
+		Topic:   mapping.topic,
+		Key:     kafkabind.MessageKey(ce),
+		Value:   value,
+		Headers: headers,
+		Time:    ce.Time,
+	}
+
+	writeCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	if err := k.writer.WriteMessages(writeCtx, msg); err != nil {
+		k.logger.Warn("CE mirror: publish failed",
+			zap.String("event_id", event.ID),
+			zap.String("ce_type", mapping.ceType),
+			zap.String("topic", mapping.topic),
+			zap.Error(err),
+		)
+		return
+	}
+	k.logger.Debug("CE mirror published",
+		zap.String("event_id", event.ID),
+		zap.String("ce_type", mapping.ceType),
+		zap.String("topic", mapping.topic),
+	)
 }
 
 // PublishMessage publishes a generic message to Kafka

--- a/internal/services/stream_stats.go
+++ b/internal/services/stream_stats.go
@@ -1,0 +1,104 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/Tributary-ai-services/aether-be/internal/logger"
+	"go.uber.org/zap"
+)
+
+// StreamStatsService queries TimescaleDB continuous aggregates to back the
+// Live Streams summary cards. It runs against tas-timescaledb-shared.events_1m
+// and falls back to a 0-value response when the DB pool is nil so the API
+// stays available if Timescale is down.
+type StreamStatsService struct {
+	db     *sql.DB
+	logger *logger.Logger
+}
+
+// StreamStats is the response shape returned by GetStats.
+type StreamStats struct {
+	EventsPerMin   int64           `json:"events_per_min"`
+	ActiveSources  int             `json:"active_sources"`
+	BySeverity     map[string]int64 `json:"by_severity"`
+	WindowMinutes  int              `json:"window_minutes"`
+	Source         string           `json:"source"` // "timescaledb" or "unavailable"
+}
+
+// NewStreamStatsService returns a stats service. Pass nil db to disable —
+// the service will return zero-value stats on every call, which keeps the
+// frontend rendering stable even when Timescale is down.
+func NewStreamStatsService(db *sql.DB, log *logger.Logger) *StreamStatsService {
+	return &StreamStatsService{
+		db:     db,
+		logger: log.WithService("stream_stats_service"),
+	}
+}
+
+// GetStats returns events-per-minute and active source count for tenantID
+// over the last 5 minutes by summing event_count from events_1m.
+func (s *StreamStatsService) GetStats(ctx context.Context, tenantID string) (*StreamStats, error) {
+	stats := &StreamStats{
+		BySeverity:    map[string]int64{},
+		WindowMinutes: 5,
+		Source:        "timescaledb",
+	}
+
+	if s.db == nil {
+		stats.Source = "unavailable"
+		return stats, nil
+	}
+
+	queryCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	const totalsQuery = `
+SELECT
+    COALESCE(SUM(event_count), 0)::bigint AS total,
+    COUNT(DISTINCT source) AS active_sources
+FROM events_1m
+WHERE bucket >= NOW() - INTERVAL '5 minutes'
+  AND ($1 = '' OR tenant_id = $1)`
+
+	if err := s.db.QueryRowContext(queryCtx, totalsQuery, tenantID).Scan(&stats.EventsPerMin, &stats.ActiveSources); err != nil {
+		s.logger.Warn("stream stats: totals query failed", zap.Error(err))
+		stats.Source = "unavailable"
+		return stats, fmt.Errorf("query totals: %w", err)
+	}
+
+	const severityQuery = `
+SELECT severity, COALESCE(SUM(event_count), 0)::bigint
+FROM events_1m
+WHERE bucket >= NOW() - INTERVAL '5 minutes'
+  AND ($1 = '' OR tenant_id = $1)
+GROUP BY severity`
+
+	rows, err := s.db.QueryContext(queryCtx, severityQuery, tenantID)
+	if err != nil {
+		s.logger.Warn("stream stats: severity query failed", zap.Error(err))
+		return stats, nil // totals are still valid
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var sev string
+		var n int64
+		if err := rows.Scan(&sev, &n); err != nil {
+			continue
+		}
+		stats.BySeverity[sev] = n
+	}
+
+	return stats, nil
+}
+
+// Close releases the underlying database connection pool.
+func (s *StreamStatsService) Close() error {
+	if s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}

--- a/internal/streaming/consumer.go
+++ b/internal/streaming/consumer.go
@@ -1,0 +1,111 @@
+package streaming
+
+import (
+	"context"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+	"go.uber.org/zap"
+
+	"github.com/Tributary-ai-services/aether-shared/go-events/topics"
+)
+
+// ConsumerConfig configures the Kafka consumer.
+type ConsumerConfig struct {
+	Brokers []string
+	GroupID string
+	Topics  []string
+}
+
+// DefaultConsumerConfig returns config for the live-feed consumer group.
+func DefaultConsumerConfig(brokers []string) ConsumerConfig {
+	return ConsumerConfig{
+		Brokers: brokers,
+		GroupID: "aether-be-live-feed",
+		Topics:  topics.ConsumerTopics(),
+	}
+}
+
+// Consumer reads CloudEvents (and legacy envelopes during migration) from
+// Kafka and broadcasts them to the Hub. It runs in its own goroutine; call
+// Stop to shut it down.
+type Consumer struct {
+	hub    *Hub
+	cfg    ConsumerConfig
+	log    *zap.Logger
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func NewConsumer(hub *Hub, cfg ConsumerConfig, log *zap.Logger) *Consumer {
+	return &Consumer{
+		hub:  hub,
+		cfg:  cfg,
+		log:  log,
+		done: make(chan struct{}),
+	}
+}
+
+// Start begins consuming in a background goroutine.
+func (c *Consumer) Start(ctx context.Context) {
+	ctx, c.cancel = context.WithCancel(ctx)
+	go c.run(ctx)
+}
+
+// Stop signals the consumer to stop and waits for it to finish.
+func (c *Consumer) Stop() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+	<-c.done
+}
+
+func (c *Consumer) run(ctx context.Context) {
+	defer close(c.done)
+
+	reader := kafka.NewReader(kafka.ReaderConfig{
+		Brokers:        c.cfg.Brokers,
+		GroupID:        c.cfg.GroupID,
+		GroupTopics:    c.cfg.Topics,
+		MinBytes:       1,
+		MaxBytes:       10e6,
+		MaxWait:        500 * time.Millisecond,
+		StartOffset:    kafka.LastOffset,
+		CommitInterval: time.Second,
+	})
+	defer reader.Close()
+
+	c.log.Info("streaming consumer started",
+		zap.Strings("topics", c.cfg.Topics),
+		zap.String("group_id", c.cfg.GroupID),
+	)
+
+	for {
+		msg, err := reader.FetchMessage(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				c.log.Info("streaming consumer shutting down")
+				return
+			}
+			c.log.Error("streaming consumer fetch error", zap.Error(err))
+			time.Sleep(time.Second)
+			continue
+		}
+
+		evt, err := ParseMessage(msg)
+		if err != nil {
+			c.log.Warn("streaming consumer parse error",
+				zap.String("topic", msg.Topic),
+				zap.Error(err),
+			)
+			reader.CommitMessages(ctx, msg)
+			continue
+		}
+
+		c.hub.Broadcast(evt)
+
+		if err := reader.CommitMessages(ctx, msg); err != nil {
+			c.log.Warn("streaming consumer commit error", zap.Error(err))
+		}
+	}
+}

--- a/internal/streaming/consumer.go
+++ b/internal/streaming/consumer.go
@@ -18,10 +18,21 @@ type ConsumerConfig struct {
 }
 
 // DefaultConsumerConfig returns config for the live-feed consumer group.
-func DefaultConsumerConfig(brokers []string) ConsumerConfig {
+//
+// groupSuffix lets each replica subscribe to its own per-pod consumer group
+// (typically the pod hostname). The WS hub is in-memory per pod, so without
+// a unique group every partition is owned by exactly one replica and CEs
+// consumed there can't reach WS connections terminated on a different pod.
+// Per-pod groups trade duplicate consume (N reads for N replicas) for correct
+// end-user fan-out. Pass "" to keep the shared single-group behavior.
+func DefaultConsumerConfig(brokers []string, groupSuffix string) ConsumerConfig {
+	groupID := "aether-be-live-feed"
+	if groupSuffix != "" {
+		groupID = groupID + "-" + groupSuffix
+	}
 	return ConsumerConfig{
 		Brokers: brokers,
-		GroupID: "aether-be-live-feed",
+		GroupID: groupID,
 		Topics:  topics.ConsumerTopics(),
 	}
 }

--- a/internal/streaming/envelope_parser.go
+++ b/internal/streaming/envelope_parser.go
@@ -1,0 +1,78 @@
+package streaming
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+
+	tasevents "github.com/Tributary-ai-services/aether-shared/go-events"
+	"github.com/Tributary-ai-services/aether-shared/go-events/kafkabind"
+)
+
+// ParseMessage detects the message format (CloudEvents vs legacy) and returns
+// a normalized CloudEvents Event. During the migration window, legacy messages
+// are converted to CE shape so the hub and Spark see one schema.
+func ParseMessage(msg kafka.Message) (tasevents.Event, error) {
+	if kafkabind.IsCloudEvent(msg.Headers) {
+		return kafkabind.Decode(msg.Value, msg.Headers)
+	}
+	return parseLegacy(msg.Value)
+}
+
+// legacyEnvelope matches the old v1 wire format from audimodal/Gatekeeper.
+type legacyEnvelope struct {
+	SchemaVersion string          `json:"schema_version"`
+	EventID       string          `json:"event_id"`
+	EventType     string          `json:"event_type"`
+	Timestamp     time.Time       `json:"timestamp"`
+	TenantID      string          `json:"tenant_id"`
+	SpaceID       string          `json:"space_id"`
+	UserID        string          `json:"user_id"`
+	RequestID     string          `json:"request_id"`
+	SourceService string          `json:"source_service"`
+	Severity      string          `json:"severity"`
+	Frameworks    []string        `json:"frameworks"`
+	Payload       json.RawMessage `json:"payload"`
+}
+
+// legacyTypeMap converts old event_type values to CloudEvents type strings.
+var legacyTypeMap = map[string]string{
+	"document.uploaded":  "com.tas.activity.document.uploaded",
+	"document.processed": "com.tas.activity.document.processed",
+	"document.failed":    "com.tas.activity.document.failed",
+	"finding":            "com.tas.compliance.finding.detected",
+	"action":             "com.tas.compliance.action.executed",
+	"audit":              "com.tas.compliance.audit.recorded",
+}
+
+func parseLegacy(value []byte) (tasevents.Event, error) {
+	var leg legacyEnvelope
+	if err := json.Unmarshal(value, &leg); err != nil {
+		return tasevents.Event{}, fmt.Errorf("unmarshal legacy: %w", err)
+	}
+
+	ceType, ok := legacyTypeMap[leg.EventType]
+	if !ok {
+		ceType = "com.tas.legacy." + leg.EventType
+	}
+
+	source := "urn:tas:service:" + leg.SourceService
+
+	return tasevents.Event{
+		SpecVersion:     tasevents.SpecVersion,
+		ID:              leg.EventID,
+		Source:          source,
+		Type:            ceType,
+		Time:            leg.Timestamp,
+		DataContentType: "application/json",
+		TenantID:        leg.TenantID,
+		SpaceID:         leg.SpaceID,
+		UserID:          leg.UserID,
+		RequestID:       leg.RequestID,
+		Severity:        tasevents.Severity(leg.Severity),
+		Frameworks:      leg.Frameworks,
+		Data:            leg.Payload,
+	}, nil
+}

--- a/internal/streaming/envelope_parser_test.go
+++ b/internal/streaming/envelope_parser_test.go
@@ -1,0 +1,91 @@
+package streaming
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+
+	tasevents "github.com/Tributary-ai-services/aether-shared/go-events"
+	"github.com/Tributary-ai-services/aether-shared/go-events/kafkabind"
+)
+
+func TestParseMessage_CloudEvents(t *testing.T) {
+	ce := tasevents.New("com.tas.activity.document.uploaded", "urn:tas:service:audimodal",
+		tasevents.WithTenant("t-acme", "sp-1"),
+		tasevents.WithData(map[string]string{"file_id": "f1"}),
+	)
+	value, headers, _ := kafkabind.Encode(ce)
+
+	msg := kafka.Message{Value: value, Headers: headers}
+	parsed, err := ParseMessage(msg)
+	if err != nil {
+		t.Fatalf("ParseMessage CE: %v", err)
+	}
+	if parsed.SpecVersion != "1.0" {
+		t.Errorf("specversion = %q", parsed.SpecVersion)
+	}
+	if parsed.Type != "com.tas.activity.document.uploaded" {
+		t.Errorf("type = %q", parsed.Type)
+	}
+	if parsed.TenantID != "t-acme" {
+		t.Errorf("tenantid = %q", parsed.TenantID)
+	}
+}
+
+func TestParseMessage_Legacy(t *testing.T) {
+	legacy := map[string]interface{}{
+		"schema_version": "1",
+		"event_id":       "legacy-uuid",
+		"event_type":     "document.uploaded",
+		"timestamp":      time.Now().UTC().Format(time.RFC3339),
+		"tenant_id":      "t-acme",
+		"user_id":        "u-alice",
+		"request_id":     "r-1",
+		"source_service": "audimodal",
+		"payload":        map[string]string{"file_id": "f1"},
+	}
+	data, _ := json.Marshal(legacy)
+
+	msg := kafka.Message{Value: data} // no CE headers
+	parsed, err := ParseMessage(msg)
+	if err != nil {
+		t.Fatalf("ParseMessage legacy: %v", err)
+	}
+	if parsed.SpecVersion != "1.0" {
+		t.Errorf("specversion = %q", parsed.SpecVersion)
+	}
+	if parsed.ID != "legacy-uuid" {
+		t.Errorf("id = %q, want legacy-uuid", parsed.ID)
+	}
+	if parsed.Type != "com.tas.activity.document.uploaded" {
+		t.Errorf("type = %q", parsed.Type)
+	}
+	if parsed.Source != "urn:tas:service:audimodal" {
+		t.Errorf("source = %q", parsed.Source)
+	}
+	if parsed.TenantID != "t-acme" {
+		t.Errorf("tenantid = %q", parsed.TenantID)
+	}
+}
+
+func TestParseMessage_UnknownLegacyType(t *testing.T) {
+	legacy := map[string]interface{}{
+		"schema_version": "1",
+		"event_id":       "u1",
+		"event_type":     "some.future.type",
+		"timestamp":      time.Now().UTC().Format(time.RFC3339),
+		"source_service": "unknown-svc",
+	}
+	data, _ := json.Marshal(legacy)
+
+	msg := kafka.Message{Value: data}
+	parsed, err := ParseMessage(msg)
+	if err != nil {
+		t.Fatalf("ParseMessage unknown: %v", err)
+	}
+	if parsed.Type != "com.tas.legacy.some.future.type" {
+		t.Errorf("type = %q, expected com.tas.legacy.some.future.type", parsed.Type)
+	}
+}

--- a/internal/streaming/hub.go
+++ b/internal/streaming/hub.go
@@ -1,0 +1,168 @@
+// Package streaming provides a Kafka-backed event hub that fans CloudEvents
+// out to WebSocket clients for the Live Streams UI panel.
+package streaming
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+
+	tasevents "github.com/Tributary-ai-services/aether-shared/go-events"
+	"github.com/gorilla/websocket"
+	"go.uber.org/zap"
+)
+
+// Conn wraps a WebSocket connection with tenant-scoped filtering.
+type Conn struct {
+	ID       string
+	TenantID string
+	TypeFilter []string // if non-empty, only deliver events matching these type prefixes
+	WS       *websocket.Conn
+	send     chan []byte
+	closed   chan struct{}
+	once     sync.Once
+}
+
+func NewConn(id, tenantID string, ws *websocket.Conn, typeFilter []string) *Conn {
+	return &Conn{
+		ID:         id,
+		TenantID:   tenantID,
+		TypeFilter: typeFilter,
+		WS:         ws,
+		send:       make(chan []byte, 256),
+		closed:     make(chan struct{}),
+	}
+}
+
+func (c *Conn) Close() {
+	c.once.Do(func() { close(c.closed) })
+}
+
+// WritePump drains the send channel to the WebSocket. Blocks until the
+// connection closes. Caller should run this in a goroutine.
+func (c *Conn) WritePump() {
+	pingTicker := time.NewTicker(30 * time.Second)
+	defer pingTicker.Stop()
+	defer c.WS.Close()
+
+	for {
+		select {
+		case msg, ok := <-c.send:
+			if !ok {
+				c.WS.WriteMessage(websocket.CloseMessage, nil)
+				return
+			}
+			c.WS.SetWriteDeadline(time.Now().Add(10 * time.Second))
+			if err := c.WS.WriteMessage(websocket.TextMessage, msg); err != nil {
+				return
+			}
+		case <-pingTicker.C:
+			c.WS.SetWriteDeadline(time.Now().Add(10 * time.Second))
+			if err := c.WS.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		case <-c.closed:
+			return
+		}
+	}
+}
+
+// ReadPump reads client messages (for keepalive). Blocks until the connection
+// closes. Caller should run this in a goroutine.
+func (c *Conn) ReadPump() {
+	defer c.Close()
+	c.WS.SetReadLimit(512)
+	c.WS.SetReadDeadline(time.Now().Add(60 * time.Second))
+	c.WS.SetPongHandler(func(string) error {
+		c.WS.SetReadDeadline(time.Now().Add(60 * time.Second))
+		return nil
+	})
+	for {
+		_, _, err := c.WS.ReadMessage()
+		if err != nil {
+			break
+		}
+	}
+}
+
+func (c *Conn) accepts(e tasevents.Event) bool {
+	if c.TenantID != "" && e.TenantID != "" && c.TenantID != e.TenantID {
+		return false
+	}
+	if len(c.TypeFilter) == 0 {
+		return true
+	}
+	for _, prefix := range c.TypeFilter {
+		if len(e.Type) >= len(prefix) && e.Type[:len(prefix)] == prefix {
+			return true
+		}
+	}
+	return false
+}
+
+// Hub manages WebSocket connections and broadcasts CloudEvents.
+type Hub struct {
+	mu    sync.RWMutex
+	conns map[string]*Conn
+	log   *zap.Logger
+}
+
+func NewHub(log *zap.Logger) *Hub {
+	return &Hub{
+		conns: make(map[string]*Conn),
+		log:   log,
+	}
+}
+
+func (h *Hub) Register(c *Conn) {
+	h.mu.Lock()
+	h.conns[c.ID] = c
+	h.mu.Unlock()
+	h.log.Info("streaming connection registered",
+		zap.String("conn_id", c.ID),
+		zap.String("tenant_id", c.TenantID),
+		zap.Int("total", h.ConnectionCount()),
+	)
+}
+
+func (h *Hub) Unregister(id string) {
+	h.mu.Lock()
+	if c, ok := h.conns[id]; ok {
+		c.Close()
+		close(c.send)
+		delete(h.conns, id)
+	}
+	h.mu.Unlock()
+}
+
+// Broadcast sends an event to all matching connections.
+func (h *Hub) Broadcast(e tasevents.Event) {
+	data, err := json.Marshal(e)
+	if err != nil {
+		h.log.Error("failed to marshal event for broadcast", zap.Error(err))
+		return
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	for _, c := range h.conns {
+		if !c.accepts(e) {
+			continue
+		}
+		select {
+		case c.send <- data:
+		default:
+			h.log.Warn("dropping event for slow connection",
+				zap.String("conn_id", c.ID),
+				zap.String("event_type", e.Type),
+			)
+		}
+	}
+}
+
+func (h *Hub) ConnectionCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.conns)
+}

--- a/internal/streaming/hub_test.go
+++ b/internal/streaming/hub_test.go
@@ -1,0 +1,119 @@
+package streaming
+
+import (
+	"testing"
+	"time"
+
+	tasevents "github.com/Tributary-ai-services/aether-shared/go-events"
+	"go.uber.org/zap"
+)
+
+func TestHub_BroadcastToMatchingConns(t *testing.T) {
+	hub := NewHub(zap.NewNop())
+
+	// Fake conn that collects sends without a real WebSocket.
+	c1 := &Conn{
+		ID:       "c1",
+		TenantID: "t-acme",
+		send:     make(chan []byte, 16),
+		closed:   make(chan struct{}),
+	}
+	c2 := &Conn{
+		ID:       "c2",
+		TenantID: "t-other",
+		send:     make(chan []byte, 16),
+		closed:   make(chan struct{}),
+	}
+	hub.Register(c1)
+	hub.Register(c2)
+
+	evt := tasevents.New("com.tas.activity.document.uploaded", "urn:tas:service:audimodal",
+		tasevents.WithTenant("t-acme", ""),
+	)
+	hub.Broadcast(evt)
+
+	// c1 should receive (tenant match)
+	select {
+	case <-c1.send:
+	case <-time.After(time.Second):
+		t.Error("c1 should have received the event")
+	}
+
+	// c2 should NOT receive (different tenant)
+	select {
+	case <-c2.send:
+		t.Error("c2 should not have received the event (wrong tenant)")
+	default:
+	}
+}
+
+func TestHub_BroadcastNoTenantFilter(t *testing.T) {
+	hub := NewHub(zap.NewNop())
+
+	c := &Conn{
+		ID:       "c1",
+		TenantID: "", // no tenant filter — accept all
+		send:     make(chan []byte, 16),
+		closed:   make(chan struct{}),
+	}
+	hub.Register(c)
+
+	evt := tasevents.New("com.tas.activity.llm.request", "urn:tas:service:llm-router",
+		tasevents.WithTenant("t-acme", ""),
+	)
+	hub.Broadcast(evt)
+
+	select {
+	case <-c.send:
+	case <-time.After(time.Second):
+		t.Error("conn with empty tenant should receive all events")
+	}
+}
+
+func TestHub_TypeFilter(t *testing.T) {
+	hub := NewHub(zap.NewNop())
+
+	c := &Conn{
+		ID:         "c1",
+		TypeFilter: []string{"com.tas.compliance."},
+		send:       make(chan []byte, 16),
+		closed:     make(chan struct{}),
+	}
+	hub.Register(c)
+
+	// Should NOT match — activity event
+	hub.Broadcast(tasevents.New("com.tas.activity.document.uploaded", "urn:tas:service:audimodal"))
+	select {
+	case <-c.send:
+		t.Error("activity event should not match compliance filter")
+	default:
+	}
+
+	// Should match — compliance event
+	hub.Broadcast(tasevents.New("com.tas.compliance.finding.detected", "urn:tas:service:gatekeeper"))
+	select {
+	case <-c.send:
+	case <-time.After(time.Second):
+		t.Error("compliance event should match compliance filter")
+	}
+}
+
+func TestHub_UnregisterClosesSendChannel(t *testing.T) {
+	hub := NewHub(zap.NewNop())
+	c := &Conn{
+		ID:     "c1",
+		send:   make(chan []byte, 16),
+		closed: make(chan struct{}),
+	}
+	hub.Register(c)
+
+	if hub.ConnectionCount() != 1 {
+		t.Fatalf("expected 1 connection, got %d", hub.ConnectionCount())
+	}
+
+	hub.Unregister("c1")
+
+	if hub.ConnectionCount() != 0 {
+		t.Fatalf("expected 0 connections, got %d", hub.ConnectionCount())
+	}
+}


### PR DESCRIPTION
## Summary
- Kafka-backed streaming hub + consumer feeding WebSocket clients
- CloudEvents mirror added to KafkaService.PublishEvent for workflow.* and security.* legacy event types; same UUID across both formats for downstream dedupe
- New MCP tool_invoked CloudEvent emitted from MCPHandler.InvokeTool on every napkin/generic-MCP dispatch
- New \`/api/v1/streams/stats\` endpoint backed by tas-timescaledb-shared events_1m continuous aggregate (with safe fallback when DB is down)

## Test plan
- [x] aether-be image builds and pods run new code
- [x] Streaming consumer joined Kafka group \`aether-be-live-feed\` with lag=0 on all 8 subscribed topics
- [x] \`TimescaleDB stats service connected — /streams/stats backed by events_1m\` log line confirmed at boot
- [x] \`GET /streams/stats\` returns 401 unauthenticated (route registered behind SpaceContext middleware)
- [x] End-to-end: real LLM chat → tas.activity.llm CloudEvent → Spark → events table row visible in TimescaleDB
- [ ] Pre-merge: confirm no Neo4j migration needed beyond existing schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)