### PR TITLE
fix: persist UserPreferences in Neo4j and wire GET handler

### DIFF
--- a/internal/handlers/routes.go
+++ b/internal/handlers/routes.go
@@ -366,7 +366,7 @@ func (s *APIServer) setupRoutes(keycloakClient *auth.KeycloakClient) {
 		users.GET("/me", s.UserHandler.GetCurrentUser)
 		users.PUT("/me", s.UserHandler.UpdateCurrentUser)
 		users.DELETE("/me", s.UserHandler.DeleteCurrentUser)
-		users.GET("/me/preferences", s.UserHandler.UpdateUserPreferences) // TODO: Change to GET handler
+		users.GET("/me/preferences", s.UserHandler.GetUserPreferences)
 		users.PUT("/me/preferences", s.UserHandler.UpdateUserPreferences)
 		users.GET("/me/stats", s.UserHandler.GetUserStats)
 		users.GET("/me/spaces", s.UserHandler.GetUserSpaces)

--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -266,6 +266,34 @@ func (h *UserHandler) SearchUsers(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
+// GetUserPreferences returns the current user's preferences.
+// @Summary Get user preferences
+// @Description Get preferences and settings for the authenticated user
+// @Tags users
+// @Produce json
+// @Security Bearer
+// @Success 200 {object} models.UserPreferences
+// @Failure 401 {object} errors.APIError
+// @Failure 500 {object} errors.APIError
+// @Router /api/v1/users/me/preferences [get]
+func (h *UserHandler) GetUserPreferences(c *gin.Context) {
+	userID := getUserID(c)
+	if userID == "" {
+		c.JSON(http.StatusUnauthorized, errors.Unauthorized("User not authenticated"))
+		return
+	}
+
+	prefs, err := h.userService.GetUserPreferences(c.Request.Context(), userID)
+	if err != nil {
+		h.logger.Error("Failed to get user preferences",
+			zap.String("user_id", userID), zap.Error(err))
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, prefs)
+}
+
 // UpdateUserPreferences updates user preferences
 // @Summary Update user preferences
 // @Description Update user preferences and settings

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -940,9 +940,83 @@ func (s *UserService) recordToUserResponse(record interface{}) (*models.UserResp
 // Redis caching methods removed - no longer using Redis
 
 // UpdateUserPreferences updates user preferences
+// GetUserPreferences returns the persisted preferences for the given user.
+//
+// User.Preferences is stored as a JSON string on the User node (see
+// UpdateUser at line 505 for the storage convention). This re-marshals it
+// into the typed models.UserPreferences shape so handlers can return a
+// stable schema to the frontend even though storage is free-form.
+//
+// Returns an empty UserPreferences (not nil) when the user has never saved
+// preferences, so callers don't need a nil check.
+func (s *UserService) GetUserPreferences(ctx context.Context, userID string) (*models.UserPreferences, error) {
+	user, err := s.GetUserByID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	prefs := &models.UserPreferences{}
+	if user.Preferences == nil || len(user.Preferences) == 0 {
+		return prefs, nil
+	}
+
+	// Round-trip the free-form map through JSON into the typed struct so
+	// any keys the struct doesn't know about are dropped, and Settings.llm
+	// (or any other nested map) survives unchanged.
+	raw, err := json.Marshal(user.Preferences)
+	if err != nil {
+		s.logger.Warn("Failed to marshal stored preferences for user",
+			zap.String("user_id", userID), zap.Error(err))
+		return prefs, nil
+	}
+	if err := json.Unmarshal(raw, prefs); err != nil {
+		s.logger.Warn("Failed to unmarshal stored preferences into typed struct",
+			zap.String("user_id", userID), zap.Error(err))
+		return prefs, nil
+	}
+	return prefs, nil
+}
+
+// UpdateUserPreferences persists the given preferences to the User node.
+//
+// Stored as a JSON string in u.preferences, matching the convention used by
+// UpdateUser at line 505. Preferences are replaced wholesale: callers send
+// the complete object, not a patch.
 func (s *UserService) UpdateUserPreferences(ctx context.Context, userID string, preferences models.UserPreferences) (*models.UserPreferences, error) {
-	// Implementation would update user preferences in Neo4j
-	s.logger.Info("Updating user preferences", zap.String("user_id", userID))
+	preferencesBytes, err := json.Marshal(preferences)
+	if err != nil {
+		s.logger.Error("Failed to serialize user preferences",
+			zap.String("user_id", userID), zap.Error(err))
+		return nil, errors.InternalWithCause("Failed to serialize user preferences", err)
+	}
+
+	query := `
+		MATCH (u:User {id: $user_id})
+		SET u.preferences = $preferences,
+		    u.updated_at = datetime($updated_at)
+		RETURN u.id
+	`
+	params := map[string]interface{}{
+		"user_id":     userID,
+		"preferences": string(preferencesBytes),
+		"updated_at":  time.Now().UTC().Format(time.RFC3339),
+	}
+
+	result, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, params)
+	if err != nil {
+		s.logger.Error("Failed to update user preferences",
+			zap.String("user_id", userID), zap.Error(err))
+		return nil, errors.Database("Failed to update user preferences", err)
+	}
+	if len(result.Records) == 0 {
+		return nil, errors.NotFoundWithDetails("User not found", map[string]interface{}{
+			"user_id": userID,
+		})
+	}
+
+	s.logger.Info("User preferences updated",
+		zap.String("user_id", userID))
+
 	return &preferences, nil
 }
 


### PR DESCRIPTION
## Summary

- `GET /users/me/preferences` was bound to `UpdateUserPreferences` (a write on a read), and `UpdateUserPreferences` itself was a stub that never touched Neo4j — any client GET/PUT round-trip silently lost data.
- `services/user.go`: real `GetUserPreferences` (marshals `u.preferences` map into the typed `UserPreferences` struct) and real `UpdateUserPreferences` (MATCH + SET `u.preferences` as JSON string, mirroring `UpdateUser`).
- `handlers/user.go`: add `GetUserPreferences` handler.
- `handlers/routes.go`: bind `GET /users/me/preferences` to the new handler.

## Why now

Unblocks the AI/LLM settings tab in [aether#feat/llm-settings-tab](https://github.com/Tributary-ai-services/aether/tree/feat/llm-settings-tab), which depends on durable per-user `settings.llm` defaults.

## Test plan

- [ ] Build clean (`go build ./...`) — verified locally
- [ ] `GET /users/me/preferences` returns the user's saved prefs (empty object for a fresh user)
- [ ] `PUT /users/me/preferences` with a `settings.llm` payload persists across pod restart
- [ ] Subsequent GET returns what was PUT
- [ ] No regression in existing user routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)