### PR TITLE
fix(space): reconcile Notebook-Space data model with as-built code

### DIFF
--- a/internal/services/space.go
+++ b/internal/services/space.go
@@ -221,8 +221,9 @@ func (s *SpaceService) GetUserSpaces(ctx context.Context, userID string) ([]*mod
 		MATCH (u:User {keycloak_id: $keycloak_id})
 
 		// Personal spaces (direct ownership)
+		// COALESCE handles legacy spaces that stored the type under 'type' instead of 'space_type'
 		OPTIONAL MATCH (u)-[:OWNS]->(personalSpace:Space)
-		WHERE personalSpace.space_type = 'personal'
+		WHERE COALESCE(personalSpace.space_type, personalSpace.type) = 'personal'
 
 		// Organization spaces (via org membership)
 		OPTIONAL MATCH (u)-[orgMembership:MEMBER_OF]->(org:Organization)-[:HAS_SPACE]->(orgSpace:Space)
@@ -247,7 +248,7 @@ func (s *SpaceService) GetUserSpaces(ctx context.Context, userID string) ([]*mod
 		RETURN DISTINCT
 		       space_info.space.id as id,
 		       space_info.space.name as name,
-		       space_info.space.space_type as type,
+		       COALESCE(space_info.space.space_type, space_info.space.type) as type,
 		       space_info.space.tenant_id as tenant_id,
 		       space_info.space.visibility as visibility,
 		       space_info.space.status as status,

--- a/migrations/002_add_space_constraints.cypher
+++ b/migrations/002_add_space_constraints.cypher
@@ -19,8 +19,10 @@ CREATE CONSTRAINT space_tenant_id_unique IF NOT EXISTS FOR (s:Space) REQUIRE s.t
 // Index on owner_id for finding spaces owned by a user/org
 CREATE INDEX space_owner_id_idx IF NOT EXISTS FOR (s:Space) ON (s.owner_id);
 
-// Index on type for filtering personal vs organization spaces
-CREATE INDEX space_type_idx IF NOT EXISTS FOR (s:Space) ON (s.type);
+// Index on space_type for filtering personal vs organization spaces
+// NOTE: the application stores the type under `space_type` (NewSpace -> space_type: $type),
+// NOT `type`. Indexing `space_type` to match actual query patterns (GetUserSpaces).
+CREATE INDEX space_type_idx IF NOT EXISTS FOR (s:Space) ON (s.space_type);
 
 // Index on status for filtering active/suspended/deleted spaces
 CREATE INDEX space_status_idx IF NOT EXISTS FOR (s:Space) ON (s.status);
@@ -28,11 +30,11 @@ CREATE INDEX space_status_idx IF NOT EXISTS FOR (s:Space) ON (s.status);
 // Index on owner_type for filtering user vs organization owned spaces
 CREATE INDEX space_owner_type_idx IF NOT EXISTS FOR (s:Space) ON (s.owner_type);
 
-// Composite index for common queries (owner + type)
-CREATE INDEX space_owner_type_composite_idx IF NOT EXISTS FOR (s:Space) ON (s.owner_id, s.type);
+// Composite index for common queries (owner + space_type)
+CREATE INDEX space_owner_type_composite_idx IF NOT EXISTS FOR (s:Space) ON (s.owner_id, s.space_type);
 
-// Composite index for active spaces by type
-CREATE INDEX space_status_type_composite_idx IF NOT EXISTS FOR (s:Space) ON (s.status, s.type);
+// Composite index for active spaces by space_type
+CREATE INDEX space_status_type_composite_idx IF NOT EXISTS FOR (s:Space) ON (s.status, s.space_type);
 
 // Full-text search index for Space name and description
 CREATE FULLTEXT INDEX space_name_description_fulltext IF NOT EXISTS FOR (s:Space) ON EACH [s.name, s.description];
@@ -72,7 +74,7 @@ WHERE name CONTAINS 'space' OR name CONTAINS 'user_personal' OR name CONTAINS 'n
 // Count existing Space nodes (should be run after migration)
 MATCH (s:Space)
 RETURN
-    s.type as space_type,
+    s.space_type as space_type,
     s.status as status,
     count(s) as count
 ORDER BY space_type, status;

--- a/migrations/005_reconcile_space_data.cypher
+++ b/migrations/005_reconcile_space_data.cypher
@@ -1,0 +1,53 @@
+// Migration: Reconcile Space/Notebook data drift
+// Applied: 2026-05-30 against production Neo4j (aether-be/neo4j-0)
+// Context: Verification (see NOTEBOOK-SPACE-RELATIONSHIP-PLAN.md, "Live Neo4j Verification")
+//          found legacy data that the runtime app never reconciled because the
+//          cypher migrations 002-004 had not been run. This migration captures the
+//          exact, idempotent fixes that were applied.
+//
+// Safe to re-run: every statement is idempotent (IF NOT EXISTS / null-guarded).
+
+// =============================================================================
+// 1. Backfill space_type from legacy `type` property
+// Older Space nodes stored the type under `type`; GetUserSpaces filters on
+// `space_type`, so those spaces were invisible to their owners.
+// =============================================================================
+MATCH (s:Space)
+WHERE s.space_type IS NULL AND s.type IS NOT NULL
+SET s.space_type = s.type, s.updated_at = datetime()
+RETURN count(s) AS space_type_backfilled;
+
+// =============================================================================
+// 2. Backfill status='active' on spaces created before the status field existed
+// (excludes anything already soft-deleted).
+// =============================================================================
+MATCH (s:Space)
+WHERE s.status IS NULL AND s.deleted_at IS NULL
+SET s.status = 'active', s.updated_at = datetime()
+RETURN count(s) AS status_backfilled;
+
+// =============================================================================
+// 3. Remove orphaned notebooks
+// Notebooks whose owner no longer exists AND whose space_id points to a Space
+// that was never created (no BELONGS_TO, no OWNED_BY, no content). Dead data.
+// =============================================================================
+MATCH (n:Notebook)
+WHERE n.space_id IS NOT NULL
+  AND NOT EXISTS { (n)-[:BELONGS_TO]->(:Space) }
+  AND NOT EXISTS { (n)-[:OWNED_BY]->(:User) }
+  AND NOT EXISTS { (:Space {id: n.space_id}) }
+DETACH DELETE n
+RETURN count(n) AS orphaned_notebooks_deleted;
+
+// =============================================================================
+// 4. Verification
+// =============================================================================
+MATCH (n:Notebook)
+RETURN count(n) AS total_notebooks,
+       count(CASE WHEN n.space_id IS NOT NULL
+                   AND NOT EXISTS { (n)-[:BELONGS_TO]->(:Space) } THEN 1 END) AS orphaned_notebooks;
+
+MATCH (s:Space)
+RETURN count(s) AS total_spaces,
+       count(CASE WHEN s.space_type IS NULL THEN 1 END) AS missing_space_type,
+       count(CASE WHEN s.status IS NULL THEN 1 END) AS missing_status;


### PR DESCRIPTION
## Summary
Reconciles the Notebook↔Space data model with the as-built implementation and fixes a property-name split that hid legacy spaces from their owners.

Root cause: the app stores a space's type under `space_type` (`NewSpace` → `space_type: $type`), but migration `002` and some legacy nodes used `type`. `GetUserSpaces` filters on `space_type`, so spaces written with only `type` were invisible to their owners — including one personal space holding **34 notebooks**.

## Changes
- **`internal/services/space.go`** — `GetUserSpaces` now uses `COALESCE(space.space_type, space.type)` so legacy spaces stored under `type` still resolve. Guards both the personal-space match and the returned `type` projection.
- **`migrations/002_add_space_constraints.cypher`** — corrected 4 occurrences from `s.type` → `s.space_type` (index + two composite indexes + verification query) to match actual query patterns.
- **`migrations/005_reconcile_space_data.cypher`** (new) — idempotent record of the data reconciliation applied to production Neo4j: backfill `space_type` from `type`, backfill `status='active'`, DETACH DELETE ownerless orphan notebooks, plus verification queries.

## Verification (live Neo4j)
- Post-fix integrity: 41 notebooks / 0 orphaned; 10 spaces / 0 missing `space_type` / 0 missing `status`.
- `space_1766596584` now resolves: `space_type='personal'`, `status='active'`, owner present, **34 notebooks** via `BELONGS_TO` — previously hidden, now returned by `GetUserSpaces`.
- Deployed and verified in-cluster (image `aether-backend:space-fix-20260531142529`, both replicas healthy).

> Base is `feature/gatekeeper-streaming` (the branch this work was cut from), so the diff is scoped to the single space commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)