### PR TITLE
fix(ci): start MinIO as a step instead of a broken service container

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -43,23 +43,22 @@ jobs:
         ports:
           - 6379:6379
       
-      minio:
-        image: minio/minio:latest
-        env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin123
-        ports:
-          - 9000:9000
-        options: >-
-          --health-cmd "curl -f http://localhost:9000/minio/health/live"
-          --health-interval 30s
-          --health-timeout 10s
-          --health-retries 3
-    
+      # NOTE: MinIO is NOT a service container. The official minio/minio image
+      # needs the `server /data` command, and GitHub Actions service containers
+      # cannot pass a command/args — so it is started as a step below.
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
+    - name: Start MinIO
+      run: |
+        docker run -d --name minio \
+          -p 9000:9000 -p 9001:9001 \
+          -e MINIO_ROOT_USER=minioadmin \
+          -e MINIO_ROOT_PASSWORD=minioadmin123 \
+          minio/minio:latest server /data --console-address ":9001"
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -55,19 +55,10 @@ jobs:
         ports:
           - 6379:6379
       
-      minio:
-        image: minio/minio:latest
-        env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin123
-        ports:
-          - 9000:9000
-        options: >-
-          --health-cmd "curl -f http://localhost:9000/minio/health/live"
-          --health-interval 30s
-          --health-timeout 10s
-          --health-retries 3
-      
+      # NOTE: MinIO is NOT a service container. The official minio/minio image
+      # needs the `server /data` command, and GitHub Actions service containers
+      # cannot pass a command/args — so it is started as a step ("Start MinIO").
+
       # Mock AudiModal service for testing
       audimodal-mock:
         image: wiremock/wiremock:latest
@@ -81,11 +72,19 @@ jobs:
     
     outputs:
       app-url: ${{ steps.deploy.outputs.app-url }}
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
+    - name: Start MinIO
+      run: |
+        docker run -d --name minio \
+          -p 9000:9000 -p 9001:9001 \
+          -e MINIO_ROOT_USER=minioadmin \
+          -e MINIO_ROOT_PASSWORD=minioadmin123 \
+          minio/minio:latest server /data --console-address ":9001"
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,23 +44,12 @@ jobs:
         ports:
           - 6379:6379
       
-      # MinIO for S3-compatible storage testing
-      minio:
-        image: minio/minio:latest
-        env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin123
-        ports:
-          - 9000:9000
-          - 9001:9001
-        options: >-
-          --health-cmd "curl -f http://localhost:9000/minio/health/live"
-          --health-interval 30s
-          --health-timeout 10s
-          --health-retries 3
-        volumes:
-          - /tmp/minio-data:/data
-      
+      # NOTE: MinIO is NOT a service container. The official minio/minio image
+      # needs the `server /data` command to start, and GitHub Actions service
+      # containers cannot pass a command/args to the image — so the container
+      # would exit at init ("print usage and quit"). It is started as a step
+      # below ("Start MinIO") using the official image with the proper command.
+
       # Mock AudiModal service for integration tests
       audimodal-mock:
         image: wiremock/wiremock:latest
@@ -75,7 +64,15 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
+    - name: Start MinIO
+      run: |
+        docker run -d --name minio \
+          -p 9000:9000 -p 9001:9001 \
+          -e MINIO_ROOT_USER=minioadmin \
+          -e MINIO_ROOT_PASSWORD=minioadmin123 \
+          minio/minio:latest server /data --console-address ":9001"
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
## Problem
Every aether-be test job has been failing at the **Initialize containers** step:
```
Failed to initialize container minio/minio:latest
One or more containers failed to start
```
GitHub Actions `services:` containers can't pass a **command** to the image. The official `minio/minio` image needs `server /data` to start — without it, the entrypoint just prints usage and the container exits unhealthy. The job dies before any Go test runs. (`Race Detection Tests`, which doesn't use the minio service, was the only test job passing.)

## Fix
Replace the `minio:` service block with a **"Start MinIO"** step in the three workflows that use it (`test.yml`, `ci-cd.yml`, `performance.yml`):
```yaml
- name: Start MinIO
  run: |
    docker run -d --name minio \
      -p 9000:9000 -p 9001:9001 \
      -e MINIO_ROOT_USER=minioadmin \
      -e MINIO_ROOT_PASSWORD=minioadmin123 \
      minio/minio:latest server /data --console-address ":9001"
```
- Keeps the **official** image (no third-party dependency — avoids the Bitnami free-image deprecation risk).
- Same ports (9000/9001), same credentials, same `/minio/health/live` endpoint — the existing "Wait for services" and bucket-setup steps are unchanged.
- `security.yml` and `progressive-testing.yml` don't use MinIO and are untouched.

## Verification
- All three workflow files validated with `yaml.safe_load`.
- No `image: minio/minio` service references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)