### PR TITLE
feat(auth): make Keycloak optional (KEYCLOAK_ENABLED) so the app runs in CI/dev

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -175,9 +175,9 @@ jobs:
         export LOG_LEVEL=info
         export GIN_MODE=release
         export PORT=8080
-        # config.Load() requires KEYCLOAK_CLIENT_SECRET when KEYCLOAK_URL is set (default);
-        # without it the app exits on boot and the health wait times out.
-        export KEYCLOAK_CLIENT_SECRET=test-secret
+        # No Keycloak server in CI: disable it so the app boots and auth is not
+        # enforced (the health/strategies checks below need no token).
+        export KEYCLOAK_ENABLED=false
 
         ./bin/aether-be &
         APP_PID=$!

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -167,6 +167,9 @@ jobs:
         export NEO4J_URI=bolt://localhost:7687
         export NEO4J_USERNAME=neo4j
         export NEO4J_PASSWORD=password
+        # CI's Community Neo4j only has the default 'neo4j' database; the app's
+        # config default is 'aether', so /health's DB check 503s without this.
+        export NEO4J_DATABASE=neo4j
         export REDIS_ADDR=localhost:6379
         export S3_ENDPOINT=http://localhost:9000
         export AWS_ACCESS_KEY_ID=minioadmin

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -64,9 +64,17 @@ func main() {
 	// Initialize external services
 	appLogger.Info("Initializing external services")
 
-	keycloakClient, err := auth.NewKeycloakClient(cfg.Keycloak, appLogger)
-	if err != nil {
-		appLogger.Fatal("Failed to initialize Keycloak client", zap.Error(err))
+	// Keycloak is optional. When disabled (KEYCLOAK_ENABLED=false) the client is
+	// nil and the auth middleware does not enforce authentication — used for local
+	// development and CI where no Keycloak server is available.
+	var keycloakClient *auth.KeycloakClient
+	if cfg.Keycloak.Enabled {
+		keycloakClient, err = auth.NewKeycloakClient(cfg.Keycloak, appLogger)
+		if err != nil {
+			appLogger.Fatal("Failed to initialize Keycloak client", zap.Error(err))
+		}
+	} else {
+		appLogger.Warn("Keycloak disabled (KEYCLOAK_ENABLED=false) - authentication will NOT be enforced")
 	}
 
 	var storageService *services.S3StorageService

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,6 +113,11 @@ type RedisConfig struct {
 
 // KeycloakConfig holds Keycloak OIDC configuration
 type KeycloakConfig struct {
+	// Enabled gates Keycloak/OIDC initialization. Default true. When false
+	// (KEYCLOAK_ENABLED=false), the app boots without an auth server and the
+	// auth middleware does not enforce authentication — intended for local
+	// development and CI where no Keycloak is available.
+	Enabled       bool
 	URL           string
 	Realm         string
 	ClientID      string
@@ -329,6 +334,7 @@ func Load() (*Config, error) {
 			PoolSize: getEnvInt("REDIS_POOL_SIZE", 10),
 		},
 		Keycloak: KeycloakConfig{
+			Enabled:       getEnvBool("KEYCLOAK_ENABLED", true),
 			URL:           getEnv("KEYCLOAK_URL", "http://localhost:8081"),
 			Realm:         getEnv("KEYCLOAK_REALM", "aether"),
 			ClientID:      getEnv("KEYCLOAK_CLIENT_ID", "aether-backend"),
@@ -565,7 +571,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("NEO4J_PASSWORD is required")
 	}
 
-	if c.Keycloak.ClientSecret == "" && c.Keycloak.URL != "" {
+	if c.Keycloak.Enabled && c.Keycloak.ClientSecret == "" && c.Keycloak.URL != "" {
 		return fmt.Errorf("KEYCLOAK_CLIENT_SECRET is required when Keycloak is configured")
 	}
 

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -17,6 +17,12 @@ import (
 // AuthMiddleware handles JWT token validation
 func AuthMiddleware(keycloakClient *auth.KeycloakClient, log *logger.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Keycloak disabled (KEYCLOAK_ENABLED=false): do not enforce authentication.
+		if keycloakClient == nil {
+			c.Next()
+			return
+		}
+
 		var idToken string
 
 		// Extract token from Authorization header
@@ -88,6 +94,12 @@ func AuthMiddleware(keycloakClient *auth.KeycloakClient, log *logger.Logger) gin
 // RequireAdmin middleware ensures user has admin privileges
 func RequireAdmin(keycloakClient *auth.KeycloakClient, log *logger.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Keycloak disabled (KEYCLOAK_ENABLED=false): no admin enforcement.
+		if keycloakClient == nil {
+			c.Next()
+			return
+		}
+
 		claims, exists := c.Get("user_claims")
 		if !exists {
 			log.Error("User claims not found in context")
@@ -133,6 +145,12 @@ func RequireAdmin(keycloakClient *auth.KeycloakClient, log *logger.Logger) gin.H
 // OptionalAuth middleware extracts user information if token is present but doesn't require it
 func OptionalAuth(keycloakClient *auth.KeycloakClient, log *logger.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Keycloak disabled (KEYCLOAK_ENABLED=false): no token verification.
+		if keycloakClient == nil {
+			c.Next()
+			return
+		}
+
 		authHeader := c.GetHeader("Authorization")
 		if authHeader == "" {
 			// No token provided, continue without authentication


### PR DESCRIPTION
Final piece of the CI repair: the **Performance → "Setup Performance Test Environment"** job failed because the app **fatally exits on boot** without a live Keycloak — `cmd/server/main.go` unconditionally called `auth.NewKeycloakClient` (→ `oidc.NewProvider` → connection refused) and `Fatal`'d. There was no way to run the app without a full auth stack.

## Change
Add a **`KEYCLOAK_ENABLED`** toggle (default **true** — production/existing behavior unchanged). When `false`:
- **config**: `KEYCLOAK_CLIENT_SECRET` no longer required; the value is read via `getEnvBool`.
- **main.go**: skip OIDC init, leave `keycloakClient` nil — mirroring the existing optional-service pattern already used for storage/kafka/postgres/audimodal.
- **auth middleware** (`AuthMiddleware`, `RequireAdmin`, `OptionalAuth`): when the client is nil, pass through without enforcing auth.

`performance.yml` "Start application" sets `KEYCLOAK_ENABLED=false`, so the app boots and the `/health` + `/api/v1/strategies` checks (which carry no token) succeed.

## Safety
- `keycloakClient` is only **stored** at construction and only **dereferenced** inside the auth middleware on protected requests — nil is safe at boot and for `/health`.
- Default is `true`; no behavior change for any environment that doesn't explicitly opt out. The disabled path logs a clear `WARN: authentication will NOT be enforced`.
- `go build`, `go vet` pass.

Completes the CI repair started in #28–#31 and #33; with this, all four workflows (Tests, Security, CI/CD, Performance) should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)