### PR TITLE
fix: prevent duplicate default agents (cached-purring-falcon)

### DIFF
--- a/internal/services/agent.go
+++ b/internal/services/agent.go
@@ -1171,6 +1171,36 @@ func (s *AgentService) getAgentFromNeo4j(ctx context.Context, agentID string) (*
 	return s.recordToAgent(*records.Records[0])
 }
 
+// HasDefaultAgent reports whether the given space already has a "default"
+// agent (default agents are tagged "default"). A personal space is meant to
+// have exactly one; this makes default-agent provisioning idempotent so
+// re-running onboarding can't create duplicates.
+func (s *AgentService) HasDefaultAgent(ctx context.Context, spaceID string) (bool, error) {
+	query := `
+		MATCH (a:Agent)
+		WHERE a.space_id = $spaceId AND 'default' IN a.tags
+		RETURN count(a) > 0 AS exists
+	`
+	params := map[string]interface{}{
+		"spaceId": spaceID,
+	}
+
+	result, err := s.neo4j.ExecuteQueryWithLogging(ctx, query, params)
+	if err != nil {
+		return false, errors.Database("Failed to check for default agent", err)
+	}
+
+	if len(result.Records) > 0 {
+		if exists, found := result.Records[0].Get("exists"); found {
+			if existsBool, ok := exists.(bool); ok {
+				return existsBool, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
 func (s *AgentService) createOwnershipRelationship(ctx context.Context, agentID, userID string) error {
 	query := `
 		MATCH (a:Agent {id: $agentId}), (u:User {id: $userId})

--- a/internal/services/onboarding.go
+++ b/internal/services/onboarding.go
@@ -150,7 +150,7 @@ func (s *OnboardingService) OnboardNewUser(ctx context.Context, user *models.Use
 				zap.Error(err),
 			)
 			// Don't fail onboarding - just log
-		} else {
+		} else if defaultAgent != nil {
 			result.DefaultAgentID = defaultAgent.AgentBuilderID
 			result.Steps[string(models.StepDefaultAgent)] = true
 			s.logger.Info("Default agent created",
@@ -158,6 +158,9 @@ func (s *OnboardingService) OnboardNewUser(ctx context.Context, user *models.Use
 				zap.String("agent_id", defaultAgent.ID),
 				zap.String("agent_builder_id", defaultAgent.AgentBuilderID),
 			)
+		} else {
+			// Skipped — a default agent already existed for this space.
+			result.Steps[string(models.StepDefaultAgent)] = true
 		}
 	}
 
@@ -467,6 +470,17 @@ func (s *OnboardingService) createDefaultAgent(
 		},
 	}
 
+	// Idempotency guard: if this space already has a default agent, skip
+	// creation so a re-run of onboarding can't create a duplicate.
+	if exists, err := s.agentService.HasDefaultAgent(ctx, spaceCtx.SpaceID); err != nil {
+		s.logger.Warn("Failed to check for existing default agent; proceeding to create",
+			zap.String("space_id", spaceCtx.SpaceID), zap.Error(err))
+	} else if exists {
+		s.logger.Info("Default agent already exists for space; skipping creation",
+			zap.String("space_id", spaceCtx.SpaceID))
+		return nil, nil
+	}
+
 	// Note: This requires authentication token for agent-builder API
 	// The token would need to be obtained from the request context
 	// For now, we'll attempt to create without token (may fail)
@@ -507,9 +521,14 @@ func (s *OnboardingService) GetOnboardingStatus(ctx context.Context, user *model
 		status.Steps[string(models.StepSampleDocuments)] = false
 	}
 
-	// Check for default agent
-	// TODO: Query agents with tag "personal-assistant"
-	status.Steps[string(models.StepDefaultAgent)] = false
+	// Check for default agent (tagged "default" in the space).
+	if spaceCtx != nil {
+		if hasAgent, err := s.agentService.HasDefaultAgent(ctx, spaceCtx.SpaceID); err != nil {
+			s.logger.Error("Failed to check for default agent", zap.Error(err))
+		} else {
+			status.Steps[string(models.StepDefaultAgent)] = hasAgent
+		}
+	}
 
 	return status, nil
 }


### PR DESCRIPTION
Backlog #2. `OnboardNewUser` runs on user creation and can run more than once (concurrent creates / re-sync), each unconditionally creating a "Personal Assistant" default agent → duplicates.

- **`AgentService.HasDefaultAgent(spaceID)`** — Neo4j count of agents in the space tagged `default` (mirrors `notebookExists`).
- **`createDefaultAgent`** now gates on it — idempotent, so a re-run skips creation; caller handles the skip (nil agent) without nil-panicking.
- Implements the `GetOnboardingStatus` default-agent TODO using the same check.

Pairs with aether #<frontend PR> (double-submit guard on AgentCreateModal). `go build`/`vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)