### PR TITLE
fix(ingress): use tas-ca-issuer instead of letsencrypt-prod

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -7,7 +7,9 @@ metadata:
     app: aether-backend
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    # Internal CA — public DNS for *.tas.scharber.com points at a private LB IP,
+    # so Let's Encrypt HTTP-01 can't validate. Matches every other TAS service.
+    cert-manager.io/cluster-issuer: "tas-ca-issuer"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"


### PR DESCRIPTION
Switches this ingress from `letsencrypt-prod` to the internal `tas-ca-issuer`.

**Why:** public DNS for `*.tas.scharber.com` resolves to a private LB IP (`192.168.1.240`), so Let's Encrypt HTTP-01 fails with *"no valid A records found"* and the cert never issues. This was the last ingress still on public ACME; every other TAS service uses the internal CA (chains to the TAS Root CA). The live cluster was already switched via kubectl on 2026-07-16; this makes it stick against a future apply / GitOps sync.

**Note on the diff size:** `k8s/ingress.yaml` was a stale CRLF file predating `.gitattributes` (`*.yaml text eol=lf`). Touching it forces git to renormalize to LF per that policy, so the diff looks large — but the only *semantic* change is the `cluster-issuer` value (`letsencrypt-prod` → `tas-ca-issuer`) plus a two-line explanatory comment. The rest is CRLF→LF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)